### PR TITLE
Only dispose controller and focus node if they are not user specified

### DIFF
--- a/lib/src/components/yg_text_field/widgets/yg_text_field_base_widget.dart
+++ b/lib/src/components/yg_text_field/widgets/yg_text_field_base_widget.dart
@@ -77,9 +77,12 @@ abstract class YgTextFieldBaseWidgetState<T extends YgTextFieldBaseWidget> exten
   void dispose() {
     _controller.removeListener(_valueUpdated);
     _focusNode.removeListener(_focusChanged);
+    // If there is no controller on the widget, the controller we are using
+    // is one the field constructed it self and it should be disposed.
     if (widget.controller == null) {
       _controller.dispose();
     }
+    // Same as controller, but for focusNode.
     if (widget.focusNode == null) {
       _focusNode.dispose();
     }


### PR DESCRIPTION
[fix] The focus node and controller on a text field are no longer disposed when they are user specified