### PR TITLE
fixed YgGauge overlapping text with Rezas changes

### DIFF
--- a/lib/src/components/yg_gauge/yg_gauge.dart
+++ b/lib/src/components/yg_gauge/yg_gauge.dart
@@ -142,7 +142,6 @@ class _YgGaugeState extends State<YgGauge> with TickerProviderStateMixin {
   Widget _buildContent(BuildContext context, BoxConstraints constraints) {
     final double topPaddingWithNotation = constraints.maxHeight / 100 * 30;
     final double topPaddingWithoutNotation = constraints.maxHeight / 100 * 35;
-    final double bottomPadding = constraints.maxHeight / 100 * 10;
 
     final String? title = widget.title;
     final String Function(double value)? buildTitle = widget.buildTitle;
@@ -165,16 +164,13 @@ class _YgGaugeState extends State<YgGauge> with TickerProviderStateMixin {
         ),
         Align(
           alignment: Alignment.bottomCenter,
-          child: Padding(
-            padding: EdgeInsets.only(bottom: bottomPadding),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                if (widget.icon != null && widget.label == null && (widget.title != null && widget.label != null))
-                  _buildIcon(context),
-                if (widget.label != null) _buildLabel(context),
-              ],
-            ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              if (widget.icon != null && widget.label == null && (widget.title != null && widget.label != null))
+                _buildIcon(context),
+              if (widget.label != null) _buildLabel(context),
+            ],
           ),
         ),
       ],
@@ -295,11 +291,11 @@ class _YgGaugePainter extends CustomPainter {
       radius: (size.width - responsiveStrokeWidth) / 2 - responsivePadding,
     );
 
-    // The start of which to dra the arc.
-    const double startAngle = math.pi * 2 * 25 / 64;
+    // The start of which to draw the arc.
+    const double startAngle = math.pi * 2 * 26 / 64;
 
     // The end of which to draw the arc.
-    const double endAngle = math.pi * 2 * 46 / 64;
+    const double endAngle = math.pi * 2 * 44 / 64;
 
     final Paint trackPainter = Paint()
       ..color = trackColor

--- a/lib/src/theme/gauge/gauge_theme.dart
+++ b/lib/src/theme/gauge/gauge_theme.dart
@@ -10,17 +10,17 @@ part 'gauge_theme.tailor.dart';
 @tailorComponent
 class _$YgGaugeTheme {
   static const List<TextStyle> titleTextStyle = <TextStyle>[
-    consumer_light.FhTextStyles.paragraph1Medium,
-    consumer_dark.FhTextStyles.paragraph1Medium,
-    professional_light.FhTextStyles.paragraph1Medium,
-    professional_dark.FhTextStyles.paragraph1Medium,
+    consumer_light.FhTextStyles.pageHeading1Medium,
+    consumer_dark.FhTextStyles.pageHeading1Medium,
+    professional_light.FhTextStyles.pageHeading1Medium,
+    professional_dark.FhTextStyles.pageHeading1Medium,
   ];
 
   static const List<TextStyle> labelTextStyle = <TextStyle>[
-    consumer_light.FhTextStyles.caption1Medium,
-    consumer_dark.FhTextStyles.caption1Medium,
-    professional_light.FhTextStyles.caption1Medium,
-    professional_dark.FhTextStyles.caption1Medium,
+    consumer_light.FhTextStyles.paragraph3Medium,
+    consumer_dark.FhTextStyles.paragraph3Medium,
+    professional_light.FhTextStyles.paragraph3Medium,
+    professional_dark.FhTextStyles.paragraph3Medium,
   ];
 
   static final List<TextStyle> notationTextStyle = <TextStyle>[


### PR DESCRIPTION
[fix] Fixed YgGauge component overlapping text. Changed the angle and removed the bottom padding, according to the latest updates in Figma. [DEV-2054]

[DEV-2054]: https://futurehome.atlassian.net/browse/DEV-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ