### PR TITLE
Fix to allow custom opening behavior implemented on dropdown controller

### DIFF
--- a/lib/src/components/fields/yg_dropdown_field/yg_dropdown_field.dart
+++ b/lib/src/components/fields/yg_dropdown_field/yg_dropdown_field.dart
@@ -278,13 +278,13 @@ abstract class YgDropdownFieldState<T extends Object, W extends YgDropdownField<
         size: widget.size,
         error: widget.error,
         states: _states,
-        onPressed: widget.disabled ? null : open,
+        onPressed: widget.disabled ? null : _controller.open,
         suffix: AnimatedRotation(
           duration: theme.animationDuration,
           curve: theme.animationCurve,
           turns: _states.opened ? 0.5 : 0,
           child: YgIconButton(
-            onPressed: widget.disabled ? null : open,
+            onPressed: widget.disabled ? null : _controller.open,
             size: YgIconButtonSize.small,
             child: const YgIcon(
               YgIcons.caretDown,


### PR DESCRIPTION
[change] Call controller.open instead of the state open method to allow overwriting the open behavior of the dropdown in the controller