### PR TITLE
tim/picker-controller-dispose-fix

### DIFF
--- a/lib/src/components/yg_picker/yg_picker_column_controller.dart
+++ b/lib/src/components/yg_picker/yg_picker_column_controller.dart
@@ -126,7 +126,7 @@ class YgPickerColumnController<T extends Object> extends ChangeNotifier {
 
   @override
   void dispose() {
-    _detach();
+    _column = null;
     _scrollController.dispose();
     super.dispose();
   }


### PR DESCRIPTION
[fix] Fixed YgPickerColumnController throwing when calling dispose more than once.