### PR TITLE
removed addPostFrameCallback

### DIFF
--- a/demo_app/pubspec.lock
+++ b/demo_app/pubspec.lock
@@ -676,7 +676,7 @@ packages:
       path: "../yggdrasil"
       relative: true
     source: path
-    version: "1.12.8"
+    version: "1.12.9"
 sdks:
   dart: ">=3.3.0 <4.0.0"
   flutter: ">=3.22.2"

--- a/yggdrasil/lib/src/utils/yg_states/mixins/yg_style_builder_mixin.dart
+++ b/yggdrasil/lib/src/utils/yg_states/mixins/yg_style_builder_mixin.dart
@@ -21,14 +21,12 @@ mixin YgStyleBuilderMixin<W extends StatefulWidget, S extends YgStyle<YgState>> 
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      _style ??= createStyle();
-      _watchedProperties.addAll(getWatchedProperties());
+    _style ??= createStyle();
+    _watchedProperties.addAll(getWatchedProperties());
 
-      for (final Listenable property in _watchedProperties) {
-        property.addListener(_rebuild);
-      }
-    });
+    for (final Listenable property in _watchedProperties) {
+      property.addListener(_rebuild);
+    }
   }
 
   void _rebuild() {


### PR DESCRIPTION
[fix] Fixed issue where widgets with build in style listeners would try to listen to a disposed style.