### PR TITLE
check for ios based for input action.

### DIFF
--- a/yggdrasil/lib/src/components/fields/search/yg_search_field/yg_search_field.dart
+++ b/yggdrasil/lib/src/components/fields/search/yg_search_field/yg_search_field.dart
@@ -351,7 +351,7 @@ class _YgSearchFieldState<T> extends StateWithYgState<YgSearchField<T>, YgSearch
             textCapitalization: widget.textCapitalization,
             inputFormatters: widget.inputFormatters,
             initialValue: widget.initialValue,
-            textInputAction: TextInputAction.none,
+            textInputAction: YgConsts.isIos ? TextInputAction.search : TextInputAction.none,
             onChanged: widget.onChanged,
             onEditingComplete: widget.onEditingComplete,
             onFocusChanged: null,

--- a/yggdrasil/lib/src/utils/yg_consts.dart
+++ b/yggdrasil/lib/src/utils/yg_consts.dart
@@ -11,6 +11,9 @@ final class YgConsts {
   /// Whether the current platform is a mobile platform.
   static final bool isMobile = !kIsWeb && (Platform.isAndroid || Platform.isIOS);
 
+  /// Whether the current platform is ios.
+  static final bool isIos = !kIsWeb && Platform.isIOS;
+
   /// The package name of yggdrasil, used for loading assets.
   static const String package = 'yggdrasil';
 }


### PR DESCRIPTION
[fix] Fixed error on ios complaining about the TextInputAction none not being supported.