### PR TITLE
Tim / Advanced search fixes

### DIFF
--- a/yggdrasil/lib/src/components/fields/search/controller/advanced_search/yg_advanced_search_controller.dart
+++ b/yggdrasil/lib/src/components/fields/search/controller/advanced_search/yg_advanced_search_controller.dart
@@ -26,7 +26,7 @@ class YgAdvancedSearchController<Value, ResultValue>
             YgSearchResultsLayout<ResultValue>, YgAdvancedSearchStateMixin<Value, ResultValue, StatefulWidget>> {
   YgAdvancedSearchController({
     YgSearchValueAndText<Value>? initialValue,
-  })  : _textEditingController = TextEditingController(),
+  })  : _textEditingController = TextEditingController(text: initialValue?.text),
         _value = initialValue?.value,
         _valueText = initialValue?.text {
     _textEditingController.addListener(_updateResults);


### PR DESCRIPTION
[fix] Fixed issue not allowing advanced search fields to clear their search query without selecting a value first.
[fix] Fixed initial value not applying to search query of advanced text field.