### PR TITLE
Tim / Use after dispose bug fix [DEV-4814]

### DIFF
--- a/yggdrasil/lib/src/utils/yg_states/mixins/yg_style_builder_mixin.dart
+++ b/yggdrasil/lib/src/utils/yg_states/mixins/yg_style_builder_mixin.dart
@@ -22,6 +22,10 @@ mixin YgStyleBuilderMixin<W extends StatefulWidget, S extends YgStyle<YgState>> 
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+
       _style ??= createStyle();
       _watchedProperties.addAll(getWatchedProperties());
 


### PR DESCRIPTION
[fix] Fixed issue where a style gets used after getting disposed if a widget is rendered for only 1 frame [DEV-4814].

[DEV-4814]: https://futurehome.atlassian.net/browse/DEV-4814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ