### PR TITLE
Kamil/siso 1729 add yg progress bar

### DIFF
--- a/demo_app/lib/screens/_screens.dart
+++ b/demo_app/lib/screens/_screens.dart
@@ -26,6 +26,7 @@ export 'mini_bar_graph/_mini_bar_graph.dart';
 export 'mobile_scanner_container/_mobile_scanner_container.dart';
 export 'picker/picker_screen.dart';
 export 'progress_indicator/_progress_indicator.dart';
+export 'progress_percentage_indicator/_progress_percentage_indicator.dart';
 export 'pulse/_pulse.dart';
 export 'radio/_radio.dart';
 export 'radio_list_tile/_radio_list_tile.dart';

--- a/demo_app/lib/screens/home_screen.dart
+++ b/demo_app/lib/screens/home_screen.dart
@@ -172,6 +172,11 @@ class HomeScreen extends StatelessWidget {
                       trailingWidgets: const <YgIcon>[YgIcon(YgIcons.caretRight)],
                     ),
                     YgListTile(
+                      title: 'ProgressPercentageIndicator',
+                      onTap: () => sl<YgRouter>().push(ProgressPercentageIndicatorScreen.route()),
+                      trailingWidgets: const <YgIcon>[YgIcon(YgIcons.caretRight)],
+                    ),
+                    YgListTile(
                       title: 'Pulse',
                       onTap: () => sl<YgRouter>().push(PulseScreen.route()),
                       trailingWidgets: const <YgIcon>[YgIcon(YgIcons.caretRight)],

--- a/demo_app/lib/screens/layout_examples/energy_optimization/_energy_optimization.dart
+++ b/demo_app/lib/screens/layout_examples/energy_optimization/_energy_optimization.dart
@@ -1,0 +1,1 @@
+export 'energy_optimization_settings_screen.dart';

--- a/demo_app/lib/screens/layout_examples/energy_optimization/energy_optimization_settings_screen.dart
+++ b/demo_app/lib/screens/layout_examples/energy_optimization/energy_optimization_settings_screen.dart
@@ -1,0 +1,147 @@
+import 'package:flutter/material.dart';
+import 'package:yggdrasil/yggdrasil.dart';
+import 'package:yggdrasil_demo/core/_core.dart';
+import 'package:yggdrasil_demo/widgets/_widgets.dart';
+
+class EnergyOptimizationSettingsScreen extends StatelessWidget {
+  const EnergyOptimizationSettingsScreen({super.key});
+
+  static const String routeName = 'EnergyOptimizationSettingsScreen';
+
+  static PageRouteBuilder<Widget> route() {
+    return const YgRouteBuilder().fadeTransition(
+      settings: const RouteSettings(name: routeName),
+      screen: const EnergyOptimizationSettingsScreen(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const DemoScreen(
+      componentName: 'Energy Optimization',
+      child: YgLayoutBody(
+        child: Column(
+          children: <Widget>[
+            // Section 1: Price guard
+            YgSection.list(
+              title: 'Price guard',
+              children: <Widget>[
+                YgListTile(
+                  title: 'Delivery area',
+                  subtitle: 'Determines your local energy pricing zone',
+                  leadingWidgets: <Widget>[YgIcon(YgIcons.pin)],
+                  trailingWidgets: <Widget>[
+                    YgTag(
+                      size: YgTagSize.small,
+                      variant: YgTagVariant.neutral,
+                      child: Text('NO2'),
+                    ),
+                    YgIcon(YgIcons.caretRight),
+                  ],
+                ),
+                YgListTile(
+                  title: 'Energy price',
+                  subtitle:
+                      'Energy usage will be optimised based on your local energy prices',
+                  leadingWidgets: <Widget>[YgIcon(YgIcons.moneyBag)],
+                  trailingWidgets: <Widget>[
+                    YgTag(
+                      size: YgTagSize.small,
+                      variant: YgTagVariant.neutral,
+                      child: Text('Fixed price'),
+                    ),
+                    YgTag(
+                      size: YgTagSize.small,
+                      variant: YgTagVariant.neutral,
+                      child: Text('3/4'),
+                    ),
+                    YgIcon(YgIcons.caretRight),
+                  ],
+                ),
+                YgListTile(
+                  title: 'Charging schedule',
+                  subtitle: 'Set preferred charging times for lower rates',
+                  leadingWidgets: <Widget>[YgIcon(YgIcons.peakTimer)],
+                  trailingWidgets: <Widget>[
+                    YgTag(
+                      size: YgTagSize.small,
+                      variant: YgTagVariant.neutral,
+                      child: Text('06:00–18:00'),
+                    ),
+                    YgIcon(YgIcons.caretRight),
+                  ],
+                ),
+              ],
+            ),
+
+            // Section 2: Max guard
+            YgSection.list(
+              title: 'Max guard',
+              children: <Widget>[
+                YgListTile(
+                  title: 'Consumption limit',
+                  subtitle:
+                      'Maintains hourly energy threshold to avoid peak grid tariffs',
+                  leadingWidgets: <Widget>[YgIcon(YgIcons.power)],
+                  trailingWidgets: <Widget>[
+                    YgTag(
+                      size: YgTagSize.small,
+                      variant: YgTagVariant.neutral,
+                      child: Text('5.0 kWh'),
+                    ),
+                    YgTag(
+                      size: YgTagSize.small,
+                      variant: YgTagVariant.neutral,
+                      child: Text('3/8'),
+                    ),
+                    YgIcon(YgIcons.caretRight),
+                  ],
+                ),
+                YgListTile(
+                  title: 'Peak average vs consumption limit',
+                  subtitle:
+                      'Compares your peak usage average against the configured limit',
+                  leadingWidgets: <Widget>[YgIcon(YgIcons.power)],
+                  trailingWidgets: <Widget>[
+                    YgTag(
+                      size: YgTagSize.small,
+                      variant: YgTagVariant.positive,
+                      child: Text('OK'),
+                    ),
+                    YgIcon(YgIcons.caretRight),
+                  ],
+                ),
+              ],
+            ),
+
+            // Section 3: Dynamic load balancing
+            YgSection.list(
+              title: 'Dynamic load balancing',
+              children: <Widget>[
+                YgListTile(
+                  title: 'Dynamic load balancing',
+                  subtitle:
+                      'Balances the consumption of your devices to protect the main breaker',
+                  leadingWidgets: <Widget>[YgIcon(YgIcons.power)],
+                  trailingWidgets: <Widget>[
+                    YgTag(
+                      size: YgTagSize.small,
+                      variant: YgTagVariant.neutral,
+                      child: Text('40 A'),
+                    ),
+                    YgTag(
+                      size: YgTagSize.small,
+                      variant: YgTagVariant.neutral,
+                      child: Text('1/3'),
+                    ),
+                    YgIcon(YgIcons.caretRight),
+                  ],
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/demo_app/lib/screens/progress_percentage_indicator/_progress_percentage_indicator.dart
+++ b/demo_app/lib/screens/progress_percentage_indicator/_progress_percentage_indicator.dart
@@ -1,0 +1,1 @@
+export 'progress_percentage_indicator_screen.dart';

--- a/demo_app/lib/screens/progress_percentage_indicator/progress_percentage_indicator_screen.dart
+++ b/demo_app/lib/screens/progress_percentage_indicator/progress_percentage_indicator_screen.dart
@@ -1,0 +1,165 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:yggdrasil/yggdrasil.dart';
+import 'package:yggdrasil_demo/core/_core.dart';
+import 'package:yggdrasil_demo/widgets/_widgets.dart';
+
+class ProgressPercentageIndicatorScreen extends StatefulWidget {
+  const ProgressPercentageIndicatorScreen({super.key});
+
+  static const String routeName = 'ProgressPercentageIndicatorScreen';
+
+  static PageRouteBuilder<Widget> route() {
+    return const YgRouteBuilder().fadeTransition(
+      settings: const RouteSettings(name: routeName),
+      screen: const ProgressPercentageIndicatorScreen(),
+    );
+  }
+
+  @override
+  State<ProgressPercentageIndicatorScreen> createState() => _ProgressPercentageIndicatorScreenState();
+}
+
+class _ProgressPercentageIndicatorScreenState extends State<ProgressPercentageIndicatorScreen> {
+  double _animatedPercentage = 0.0;
+  Timer? _timer;
+
+  double _devicePercentage = 0.0;
+  Timer? _deviceTimer;
+  final Random _random = Random();
+
+  @override
+  void initState() {
+    super.initState();
+    _startSimulation();
+    _startDeviceSimulation();
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    _deviceTimer?.cancel();
+    super.dispose();
+  }
+
+  void _startSimulation() {
+    _timer?.cancel();
+    _animatedPercentage = 0.0;
+    _timer = Timer.periodic(const Duration(milliseconds: 50), (Timer timer) {
+      setState(() {
+        _animatedPercentage += 0.005;
+        if (_animatedPercentage >= 1.0) {
+          _animatedPercentage = 0.0;
+        }
+      });
+    });
+  }
+
+  void _startDeviceSimulation() {
+    _deviceTimer?.cancel();
+    _devicePercentage = 0.0;
+    _scheduleNextDeviceUpdate();
+  }
+
+  void _scheduleNextDeviceUpdate() {
+    final int delaySeconds = 10 + _random.nextInt(11); // 10–20 seconds
+    _deviceTimer = Timer(Duration(seconds: delaySeconds), () {
+      if (!mounted) return;
+      setState(() {
+        _devicePercentage += 0.05 + _random.nextDouble() * 0.1; // +5–15%
+        if (_devicePercentage >= 1.0) {
+          _devicePercentage = 0.0;
+        }
+      });
+      _scheduleNextDeviceUpdate();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final int remainingSeconds = ((1.0 - _animatedPercentage) * 90).round();
+    final int totalMB = 212;
+    final int uploadedMB = (_animatedPercentage * totalMB).round();
+
+    final int deviceRemainingSeconds = ((1.0 - _devicePercentage) * 180).round();
+    final int deviceTotalMB = 512;
+    final int deviceUploadedMB = (_devicePercentage * deviceTotalMB).round();
+
+    return DemoScreen(
+      componentName: 'ProgressPercentageIndicator',
+      child: YgLayoutBody(
+        child: Column(
+          children: <Widget>[
+            YgSection(
+              title: 'Device update simulation',
+              subtitle: 'Updates every 10–20 sec',
+              child: YgProgressPercentageIndicator(
+                percentage: _devicePercentage,
+                timeRemaining: '~$deviceRemainingSeconds sec',
+                remainingSubtitle: 'remaining',
+                title: 'Firmware update',
+                subtitle: '$deviceUploadedMB of $deviceTotalMB packages',
+              ),
+            ),
+            const YgSection(
+              title: 'Static - 67%',
+              subtitle: 'With title and subtitle.',
+              child: YgProgressPercentageIndicator(
+                percentage: 0.67,
+                timeRemaining: '~59 sec',
+                remainingSubtitle: 'remaining',
+                title: 'Uploading files',
+                subtitle: '142 of 212 MB',
+              ),
+            ),
+            const YgSection(
+              title: 'Static - 25%',
+              subtitle: 'Early progress.',
+              child: YgProgressPercentageIndicator(
+                percentage: 0.25,
+                timeRemaining: '~3 min',
+                remainingSubtitle: 'remaining',
+                title: 'Downloading update',
+                subtitle: '64 of 256 MB',
+              ),
+            ),
+            const YgSection(
+              title: 'Static - 90%',
+              subtitle: 'Almost complete.',
+              child: YgProgressPercentageIndicator(
+                percentage: 0.9,
+                timeRemaining: '~10 sec',
+                remainingSubtitle: 'remaining',
+                title: 'Processing data',
+                subtitle: '900 of 1000 items',
+              ),
+            ),
+            const YgSection(
+              title: 'Without title & subtitle',
+              subtitle: 'Minimal variant.',
+              child: YgProgressPercentageIndicator(
+                percentage: 0.5,
+                timeRemaining: '~2 min',
+                remainingSubtitle: 'remaining',
+              ),
+            ),
+            const YgSection(
+              title: 'Animation disabled',
+              subtitle: 'isAnimated: false — no shimmer overlay.',
+              child: YgProgressPercentageIndicator(
+                percentage: 0.45,
+                timeRemaining: '~1 min',
+                remainingSubtitle: 'remaining',
+                title: 'Syncing',
+                subtitle: '45 of 100 files',
+                isAnimated: false,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/demo_app/lib/screens/progress_percentage_indicator/progress_percentage_indicator_screen.dart
+++ b/demo_app/lib/screens/progress_percentage_indicator/progress_percentage_indicator_screen.dart
@@ -23,9 +23,6 @@ class ProgressPercentageIndicatorScreen extends StatefulWidget {
 }
 
 class _ProgressPercentageIndicatorScreenState extends State<ProgressPercentageIndicatorScreen> {
-  double _animatedPercentage = 0.0;
-  Timer? _timer;
-
   double _devicePercentage = 0.0;
   Timer? _deviceTimer;
   final Random _random = Random();
@@ -33,28 +30,13 @@ class _ProgressPercentageIndicatorScreenState extends State<ProgressPercentageIn
   @override
   void initState() {
     super.initState();
-    _startSimulation();
     _startDeviceSimulation();
   }
 
   @override
   void dispose() {
-    _timer?.cancel();
     _deviceTimer?.cancel();
     super.dispose();
-  }
-
-  void _startSimulation() {
-    _timer?.cancel();
-    _animatedPercentage = 0.0;
-    _timer = Timer.periodic(const Duration(milliseconds: 50), (Timer timer) {
-      setState(() {
-        _animatedPercentage += 0.005;
-        if (_animatedPercentage >= 1.0) {
-          _animatedPercentage = 0.0;
-        }
-      });
-    });
   }
 
   void _startDeviceSimulation() {
@@ -79,10 +61,6 @@ class _ProgressPercentageIndicatorScreenState extends State<ProgressPercentageIn
 
   @override
   Widget build(BuildContext context) {
-    final int remainingSeconds = ((1.0 - _animatedPercentage) * 90).round();
-    final int totalMB = 212;
-    final int uploadedMB = (_animatedPercentage * totalMB).round();
-
     final int deviceRemainingSeconds = ((1.0 - _devicePercentage) * 180).round();
     final int deviceTotalMB = 512;
     final int deviceUploadedMB = (_devicePercentage * deviceTotalMB).round();

--- a/demo_app/lib/screens/wizard_header_screen/wizard_header_screen.dart
+++ b/demo_app/lib/screens/wizard_header_screen/wizard_header_screen.dart
@@ -23,7 +23,7 @@ class WizardHeaderScreen extends StatelessWidget {
       componentName: 'WizardHeader',
       child: YgLayoutBody(
         child: Column(
-          children: [
+          children: <Widget>[
             Column(
               children: List<Widget>.generate(
                 10,

--- a/demo_app/macos/Podfile.lock
+++ b/demo_app/macos/Podfile.lock
@@ -1,85 +1,29 @@
 PODS:
-  - connectivity_plus (0.0.1):
-    - FlutterMacOS
-    - ReachabilitySwift
-  - device_info_plus (0.0.1):
-    - FlutterMacOS
-  - flutter_blue_plus (0.0.1):
-    - FlutterMacOS
-  - flutter_secure_storage_macos (6.1.1):
-    - FlutterMacOS
   - FlutterMacOS (1.0.0)
-  - geolocator_apple (1.2.0):
-    - FlutterMacOS
   - package_info_plus (0.0.1):
-    - FlutterMacOS
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - ReachabilitySwift (5.0.0)
-  - share_plus (0.0.1):
     - FlutterMacOS
   - shared_preferences_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
-  - url_launcher_macos (0.0.1):
-    - FlutterMacOS
 
 DEPENDENCIES:
-  - connectivity_plus (from `Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos`)
-  - device_info_plus (from `Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos`)
-  - flutter_blue_plus (from `Flutter/ephemeral/.symlinks/plugins/flutter_blue_plus/macos`)
-  - flutter_secure_storage_macos (from `Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos`)
   - FlutterMacOS (from `Flutter/ephemeral`)
-  - geolocator_apple (from `Flutter/ephemeral/.symlinks/plugins/geolocator_apple/macos`)
   - package_info_plus (from `Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos`)
-  - path_provider_foundation (from `Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin`)
-  - share_plus (from `Flutter/ephemeral/.symlinks/plugins/share_plus/macos`)
   - shared_preferences_foundation (from `Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin`)
-  - url_launcher_macos (from `Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos`)
-
-SPEC REPOS:
-  trunk:
-    - ReachabilitySwift
 
 EXTERNAL SOURCES:
-  connectivity_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/connectivity_plus/macos
-  device_info_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/device_info_plus/macos
-  flutter_blue_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/flutter_blue_plus/macos
-  flutter_secure_storage_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/flutter_secure_storage_macos/macos
   FlutterMacOS:
     :path: Flutter/ephemeral
-  geolocator_apple:
-    :path: Flutter/ephemeral/.symlinks/plugins/geolocator_apple/macos
   package_info_plus:
     :path: Flutter/ephemeral/.symlinks/plugins/package_info_plus/macos
-  path_provider_foundation:
-    :path: Flutter/ephemeral/.symlinks/plugins/path_provider_foundation/darwin
-  share_plus:
-    :path: Flutter/ephemeral/.symlinks/plugins/share_plus/macos
   shared_preferences_foundation:
     :path: Flutter/ephemeral/.symlinks/plugins/shared_preferences_foundation/darwin
-  url_launcher_macos:
-    :path: Flutter/ephemeral/.symlinks/plugins/url_launcher_macos/macos
 
 SPEC CHECKSUMS:
-  connectivity_plus: 18d3c32514c886e046de60e9c13895109866c747
-  device_info_plus: 5401765fde0b8d062a2f8eb65510fb17e77cf07f
-  flutter_blue_plus: e2868679021f19d12a8c0c58a33f1df66ec7fa6a
-  flutter_secure_storage_macos: d56e2d218c1130b262bef8b4a7d64f88d7f9c9ea
-  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  geolocator_apple: 72a78ae3f3e4ec0db62117bd93e34523f5011d58
-  package_info_plus: 02d7a575e80f194102bef286361c6c326e4c29ce
-  path_provider_foundation: 29f094ae23ebbca9d3d0cec13889cd9060c0e943
-  ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
-  share_plus: 76dd39142738f7a68dd57b05093b5e8193f220f7
-  shared_preferences_foundation: 5b919d13b803cadd15ed2dc053125c68730e5126
-  url_launcher_macos: d2691c7dd33ed713bf3544850a623080ec693d95
+  FlutterMacOS: d0db08ddef1a9af05a5ec4b724367152bb0500b1
+  package_info_plus: 4f85435d47d3cdedb9b420d168afd080840708ea
+  shared_preferences_foundation: 9e1978ff2562383bd5676f64ec4e9aa8fa06a6f7
 
 PODFILE CHECKSUM: 2f6d3cbb087db019d823f42cc3db63c334d8fdb3
 
-COCOAPODS: 1.14.3
+COCOAPODS: 1.16.2

--- a/demo_app/macos/Runner.xcodeproj/project.pbxproj
+++ b/demo_app/macos/Runner.xcodeproj/project.pbxproj
@@ -202,7 +202,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 1430;
+				LastUpgradeCheck = 1510;
 				ORGANIZATIONNAME = "";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {

--- a/demo_app/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/demo_app/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1430"
+   LastUpgradeVersion = "1510"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -48,6 +48,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/demo_app/macos/Runner/AppDelegate.swift
+++ b/demo_app/macos/Runner/AppDelegate.swift
@@ -1,9 +1,13 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    return true
+  }
+
+  override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
   }
 }

--- a/demo_app/pubspec.lock
+++ b/demo_app/pubspec.lock
@@ -5,23 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
+      sha256: "0b2f2bd91ba804e53a61d757b986f89f1f9eaed5b11e4b2f5a2468d86d6c9fc7"
       url: "https://pub.dev"
     source: hosted
-    version: "76.0.0"
-  _macros:
-    dependency: transitive
-    description: dart
-    source: sdk
-    version: "0.3.3"
+    version: "67.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
+      sha256: "37577842a27e4338429a1cbc32679d508836510b056f1eedf0c8d20e39c1383d"
       url: "https://pub.dev"
     source: hosted
-    version: "6.11.0"
+    version: "6.4.1"
   archive:
     dependency: transitive
     description:
@@ -82,18 +77,18 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   code_builder:
     dependency: transitive
     description:
@@ -106,10 +101,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -130,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "7856d364b589d1f08986e140938578ed36ed948581fbc3bc9aef1805039ac5ab"
+      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.7"
+    version: "2.3.6"
   dotted_border:
     dependency: "direct main"
     description:
@@ -146,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -249,42 +244,42 @@ packages:
     dependency: transitive
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      sha256: "1ce844379ca14835a50d2f019a3099f419082cfdd231cd86a142af94dd5c6bb1"
+      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
       url: "https://pub.dev"
     source: hosted
-    version: "4.9.0"
+    version: "4.11.0"
   leak_tracker:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "11.0.2"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -309,38 +304,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.2"
-  macros:
-    dependency: transitive
-    description:
-      name: macros
-      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.3-main.0"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.0"
   mockito:
     dependency: "direct main"
     description:
@@ -385,10 +372,10 @@ packages:
     dependency: transitive
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_drawing:
     dependency: transitive
     description:
@@ -550,18 +537,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -590,16 +577,16 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.9"
   theme_tailor_annotation:
     dependency: transitive
     description:
       path: "packages/theme_tailor_annotation"
-      ref: "flutter-update/3.27.4"
-      resolved-ref: f80a81532f6c9387fd99e95fa4cf3d33a85847ff
+      ref: "kamil/update-to-flutter-3.41.2"
+      resolved-ref: b86851fab61e3065964c7e45639d46b94a5697e0
       url: "git@github.com:futurehomeno/theme_tailor.git"
     source: git
     version: "2.0.0"
@@ -639,10 +626,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -705,7 +692,7 @@ packages:
       path: "../yggdrasil"
       relative: true
     source: path
-    version: "1.13.5"
+    version: "2.0.6"
 sdks:
-  dart: ">=3.6.2 <4.0.0"
-  flutter: ">=3.27.4"
+  dart: "3.11.0"
+  flutter: ">=3.41.2"

--- a/yggdrasil/lib/src/components/fields/helpers/yg_validate_helper.dart
+++ b/yggdrasil/lib/src/components/fields/helpers/yg_validate_helper.dart
@@ -92,7 +92,7 @@ class YgValidateHelper<T> {
 
   /// Handler for when the user finishes editing a field.
   void onEditingComplete() {
-    final VoidCallback? onEditingComplete = this._onEditingComplete;
+    final VoidCallback? onEditingComplete = _onEditingComplete;
 
     if (_autoValidate == YgAutoValidate.onComplete && !_key.validate()) {
       return;

--- a/yggdrasil/lib/src/components/yg_picker/yg_picker_column_controller.dart
+++ b/yggdrasil/lib/src/components/yg_picker/yg_picker_column_controller.dart
@@ -106,7 +106,7 @@ class YgPickerColumnController<T extends Object> extends ChangeNotifier
   void attach(_YgPickerColumnState<T> column) {
     _column = column;
 
-    final T? value = this._value;
+    final T? value = _value;
     if (value == null) {
       return;
     }

--- a/yggdrasil/lib/src/components/yg_progress_indicator/_yg_progress_indicator.dart
+++ b/yggdrasil/lib/src/components/yg_progress_indicator/_yg_progress_indicator.dart
@@ -1,2 +1,3 @@
 export 'yg_circular_progress_indicator.dart';
 export 'yg_linear_progress_indicator.dart';
+export 'yg_progress_percentage_indicator.dart';

--- a/yggdrasil/lib/src/components/yg_progress_indicator/yg_progress_percentage_indicator.dart
+++ b/yggdrasil/lib/src/components/yg_progress_indicator/yg_progress_percentage_indicator.dart
@@ -1,0 +1,282 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:yggdrasil/src/theme/_theme.dart';
+import 'package:yggdrasil/src/utils/_utils.dart';
+
+/// Displays a progress percentage with a [YgLinearProgressIndicator],
+/// time remaining, and an optional animated shimmer overlay.
+class YgProgressPercentageIndicator extends StatefulWidget with StatefulWidgetDebugMixin {
+  const YgProgressPercentageIndicator({
+    super.key,
+    required this.percentage,
+    required this.timeRemaining,
+    required this.remainingSubtitle,
+    this.title,
+    this.subtitle,
+    this.isAnimated = true,
+  });
+
+  /// Current progress value in range of 0.0 to 1.0.
+  final double percentage;
+
+  /// Text describing the remaining time, e.g. "~59 sec".
+  final String timeRemaining;
+
+  /// Label shown below [timeRemaining], e.g. "remaining".
+  final String remainingSubtitle;
+
+  /// Optional title shown above the percentage, e.g. "Uploading files".
+  final String? title;
+
+  /// Optional subtitle shown below the progress bar, e.g. "142 of 212 MB".
+  final String? subtitle;
+
+  /// Whether the shimmer overlay animation is active.
+  final bool isAnimated;
+
+  @override
+  State<YgProgressPercentageIndicator> createState() => _YgProgressPercentageIndicatorState();
+}
+
+class _YgProgressPercentageIndicatorState extends State<YgProgressPercentageIndicator>
+    with SingleTickerProviderStateMixin {
+  late final AnimationController _shimmerController;
+
+  @override
+  void initState() {
+    super.initState();
+    _shimmerController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1500),
+    );
+    if (widget.isAnimated) {
+      _shimmerController.repeat();
+    }
+  }
+
+  @override
+  void didUpdateWidget(YgProgressPercentageIndicator oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.isAnimated != oldWidget.isAnimated) {
+      if (widget.isAnimated) {
+        _shimmerController.repeat();
+      } else {
+        _shimmerController.stop();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _shimmerController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ProgressPercentageIndicatorTheme theme = context.progressIndicatorTheme.progressPercentageIndicatorTheme;
+    final LinearProgressIndicatorTheme linearTheme = context.progressIndicatorTheme.linearProgressIndicatorTheme;
+
+    final String? title = widget.title;
+    final String? subtitle = widget.subtitle;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        if (title != null)
+          Padding(
+            padding: EdgeInsets.only(bottom: theme.contentSpacing),
+            child: Text(title, style: theme.titleTextStyle),
+          ),
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: <Widget>[
+            Text(
+              '${(widget.percentage * 100).round()} %',
+              style: theme.percentageTextStyle,
+            ),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              mainAxisSize: MainAxisSize.min,
+              children: <Widget>[
+                Text(widget.timeRemaining, style: theme.timeRemainingTextStyle),
+                Text(widget.remainingSubtitle, style: theme.remainingSubtitleTextStyle),
+              ],
+            ),
+          ],
+        ),
+        SizedBox(height: theme.contentSpacing),
+        TweenAnimationBuilder<double>(
+          tween: Tween<double>(end: widget.percentage),
+          duration: const Duration(milliseconds: 500),
+          curve: Curves.easeInOut,
+          builder: (BuildContext context, double animatedValue, Widget? child) {
+            return ClipRRect(
+              borderRadius: linearTheme.borderRadius,
+              child: SizedBox(
+                height: theme.progressBarHeight,
+                child: Stack(
+                  children: <Widget>[
+                    Positioned.fill(
+                      child: RepaintBoundary(
+                        child: LinearProgressIndicator(
+                          value: animatedValue,
+                          color: linearTheme.color,
+                          backgroundColor: linearTheme.backgroundColor,
+                        ),
+                      ),
+                    ),
+                    if (widget.isAnimated)
+                      Positioned.fill(
+                        child: _ShimmerOverlay(
+                          controller: _shimmerController,
+                          percentage: animatedValue,
+                          shimmerColor: theme.shimmerColor,
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+        if (subtitle != null)
+          Padding(
+            padding: EdgeInsets.only(top: theme.contentSpacing),
+            child: Text(subtitle, style: theme.subtitleTextStyle),
+          ),
+      ],
+    );
+  }
+}
+
+class _ShimmerOverlay extends LeafRenderObjectWidget {
+  const _ShimmerOverlay({
+    required this.controller,
+    required this.percentage,
+    required this.shimmerColor,
+  });
+
+  final AnimationController controller;
+  final double percentage;
+  final Color shimmerColor;
+
+  @override
+  RenderObject createRenderObject(BuildContext context) {
+    return _ShimmerRenderBox(
+      controller: controller,
+      percentage: percentage,
+      shimmerColor: shimmerColor,
+    );
+  }
+
+  @override
+  void updateRenderObject(BuildContext context, covariant _ShimmerRenderBox renderObject) {
+    renderObject
+      ..percentage = percentage
+      ..shimmerColor = shimmerColor;
+  }
+}
+
+class _ShimmerRenderBox extends RenderBox {
+  _ShimmerRenderBox({
+    required AnimationController controller,
+    required double percentage,
+    required Color shimmerColor,
+  }) : _controller = controller,
+       _percentage = percentage,
+       _shimmerColor = shimmerColor {
+    _controller.addListener(markNeedsPaint);
+  }
+
+  final AnimationController _controller;
+
+  double _percentage;
+  set percentage(double value) {
+    if (_percentage != value) {
+      _percentage = value;
+      markNeedsPaint();
+    }
+  }
+
+  Color _shimmerColor;
+  set shimmerColor(Color value) {
+    if (_shimmerColor != value) {
+      _shimmerColor = value;
+      markNeedsPaint();
+    }
+  }
+
+  @override
+  bool get isRepaintBoundary => true;
+
+  @override
+  void attach(PipelineOwner owner) {
+    super.attach(owner);
+    _controller.addListener(markNeedsPaint);
+  }
+
+  @override
+  void detach() {
+    _controller.removeListener(markNeedsPaint);
+    super.detach();
+  }
+
+  @override
+  void performLayout() {
+    size = constraints.biggest;
+  }
+
+  static const double _shimmerWidthRatio = 0.4;
+
+  @override
+  void paint(PaintingContext context, Offset offset) {
+    final double filledWidth = size.width * _percentage.clamp(0.0, 1.0);
+    if (filledWidth <= 0) return;
+
+    final double animValue = _controller.value;
+
+    // The shimmer band travels from left edge to right edge of the filled area.
+    // We extend the travel range so the band fully enters and exits.
+    final double bandWidth = filledWidth * _shimmerWidthRatio;
+    final double travelDistance = filledWidth + bandWidth;
+    final double bandCenter = -bandWidth / 2 + travelDistance * animValue;
+
+    final double bandStart = bandCenter - bandWidth / 2;
+    final double bandEnd = bandCenter + bandWidth / 2;
+
+    // Clamp drawing to the filled region.
+    final double drawStart = bandStart.clamp(0.0, filledWidth);
+    final double drawEnd = bandEnd.clamp(0.0, filledWidth);
+    if (drawEnd <= drawStart) return;
+
+    final Rect shimmerRect = Rect.fromLTWH(
+      offset.dx + drawStart,
+      offset.dy,
+      drawEnd - drawStart,
+      size.height,
+    );
+
+    // Gradient stop positions relative to the full band.
+    final double gradientStart = offset.dx + bandStart;
+    final double gradientEnd = offset.dx + bandEnd;
+
+    final Paint paint = Paint()
+      ..shader =
+          LinearGradient(
+            colors: <Color>[
+              _shimmerColor.withValues(alpha: 0),
+              _shimmerColor,
+              _shimmerColor,
+              _shimmerColor.withValues(alpha: 0),
+            ],
+            stops: const <double>[0.0, 0.35, 0.65, 1.0],
+          ).createShader(
+            Rect.fromLTRB(gradientStart, offset.dy, gradientEnd, offset.dy + size.height),
+          );
+
+    context.canvas.drawRect(shimmerRect, paint);
+  }
+}

--- a/yggdrasil/lib/src/components/yg_progress_indicator/yg_progress_percentage_indicator.dart
+++ b/yggdrasil/lib/src/components/yg_progress_indicator/yg_progress_percentage_indicator.dart
@@ -3,7 +3,7 @@ import 'package:flutter/rendering.dart';
 import 'package:yggdrasil/src/theme/_theme.dart';
 import 'package:yggdrasil/src/utils/_utils.dart';
 
-/// Displays a progress percentage with a [YgLinearProgressIndicator],
+/// Displays a progress percentage with a [LinearProgressIndicator],
 /// time remaining, and an optional animated shimmer overlay.
 class YgProgressPercentageIndicator extends StatefulWidget with StatefulWidgetDebugMixin {
   const YgProgressPercentageIndicator({
@@ -187,9 +187,7 @@ class _ShimmerRenderBox extends RenderBox {
     required Color shimmerColor,
   }) : _controller = controller,
        _percentage = percentage,
-       _shimmerColor = shimmerColor {
-    _controller.addListener(markNeedsPaint);
-  }
+       _shimmerColor = shimmerColor;
 
   final AnimationController _controller;
 

--- a/yggdrasil/lib/src/theme/helpers/theme_data_helper.dart
+++ b/yggdrasil/lib/src/theme/helpers/theme_data_helper.dart
@@ -19,7 +19,7 @@ class YgThemeDataHelper {
       highlightColor: theme.defaults.highlightColor,
       focusColor: theme.defaults.focusColor,
       // Temporary theme values. Will be removed once we have proper component.
-      appBarTheme: AppBarTheme(color: theme.defaults.appBarColor),
+      appBarTheme: AppBarTheme(backgroundColor: theme.defaults.appBarColor),
       iconTheme: IconThemeData(
         color: theme.defaults.iconColor,
       ),

--- a/yggdrasil/lib/src/theme/progress_indicator/extensions/_extensions.dart
+++ b/yggdrasil/lib/src/theme/progress_indicator/extensions/_extensions.dart
@@ -1,2 +1,3 @@
 export 'circular_progress_indicator_theme.dart';
 export 'linear_progress_indicator_theme.dart';
+export 'progress_percentage_indicator_theme.dart';

--- a/yggdrasil/lib/src/theme/progress_indicator/extensions/progress_percentage_indicator_theme.dart
+++ b/yggdrasil/lib/src/theme/progress_indicator/extensions/progress_percentage_indicator_theme.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:theme_tailor_annotation/theme_tailor_annotation.dart';
+import 'package:yggdrasil/src/tokens/consumer_dark/_consumer_dark.dart' as consumer_dark;
+import 'package:yggdrasil/src/tokens/consumer_light/_consumer_light.dart' as consumer_light;
+import 'package:yggdrasil/src/tokens/professional_dark/_professional_dark.dart' as professional_dark;
+import 'package:yggdrasil/src/tokens/professional_light/_professional_light.dart' as professional_light;
+
+part 'progress_percentage_indicator_theme.tailor.dart';
+
+@tailorComponent
+class _$ProgressPercentageIndicatorTheme {
+  static final List<TextStyle> titleTextStyle = <TextStyle>[
+    consumer_light.FhTextStyles.paragraph3Regular.copyWith(color: consumer_light.FhColors.textWeak),
+    consumer_dark.FhTextStyles.paragraph3Regular.copyWith(color: consumer_dark.FhColors.textWeak),
+    professional_light.FhTextStyles.paragraph3Regular.copyWith(color: professional_light.FhColors.textWeak),
+    professional_dark.FhTextStyles.paragraph3Regular.copyWith(color: professional_dark.FhColors.textWeak),
+  ];
+
+  static final List<TextStyle> percentageTextStyle = <TextStyle>[
+    consumer_light.FhTextStyles.display3Bold.copyWith(color: consumer_light.FhColors.textDefault),
+    consumer_dark.FhTextStyles.display3Bold.copyWith(color: consumer_dark.FhColors.textDefault),
+    professional_light.FhTextStyles.display3Bold.copyWith(color: professional_light.FhColors.textDefault),
+    professional_dark.FhTextStyles.display3Bold.copyWith(color: professional_dark.FhColors.textDefault),
+  ];
+
+  static final List<TextStyle> timeRemainingTextStyle = <TextStyle>[
+    consumer_light.FhTextStyles.paragraph2Bold.copyWith(color: consumer_light.FhColors.textDefault),
+    consumer_dark.FhTextStyles.paragraph2Bold.copyWith(color: consumer_dark.FhColors.textDefault),
+    professional_light.FhTextStyles.paragraph2Bold.copyWith(color: professional_light.FhColors.textDefault),
+    professional_dark.FhTextStyles.paragraph2Bold.copyWith(color: professional_dark.FhColors.textDefault),
+  ];
+
+  static final List<TextStyle> remainingSubtitleTextStyle = <TextStyle>[
+    consumer_light.FhTextStyles.caption1Regular.copyWith(color: consumer_light.FhColors.textWeak),
+    consumer_dark.FhTextStyles.caption1Regular.copyWith(color: consumer_dark.FhColors.textWeak),
+    professional_light.FhTextStyles.caption1Regular.copyWith(color: professional_light.FhColors.textWeak),
+    professional_dark.FhTextStyles.caption1Regular.copyWith(color: professional_dark.FhColors.textWeak),
+  ];
+
+  static final List<TextStyle> subtitleTextStyle = <TextStyle>[
+    consumer_light.FhTextStyles.caption1Medium.copyWith(color: consumer_light.FhColors.textWeak),
+    consumer_dark.FhTextStyles.caption1Medium.copyWith(color: consumer_dark.FhColors.textWeak),
+    professional_light.FhTextStyles.caption1Medium.copyWith(color: professional_light.FhColors.textWeak),
+    professional_dark.FhTextStyles.caption1Medium.copyWith(color: professional_dark.FhColors.textWeak),
+  ];
+
+  static const List<Color> shimmerColor = <Color>[
+    Color(0x40ffffff),
+    Color(0x40ffffff),
+    Color(0x40ffffff),
+    Color(0x40ffffff),
+  ];
+
+  static const List<double> contentSpacing = <double>[
+    consumer_light.FhDimensions.xs,
+    consumer_dark.FhDimensions.xs,
+    professional_light.FhDimensions.xs,
+    professional_dark.FhDimensions.xs,
+  ];
+
+  static const List<double> progressBarHeight = <double>[
+    consumer_light.FhDimensions.xs,
+    consumer_dark.FhDimensions.xs,
+    professional_light.FhDimensions.xs,
+    professional_dark.FhDimensions.xs,
+  ];
+}

--- a/yggdrasil/lib/src/theme/progress_indicator/extensions/progress_percentage_indicator_theme.tailor.dart
+++ b/yggdrasil/lib/src/theme/progress_indicator/extensions/progress_percentage_indicator_theme.tailor.dart
@@ -1,0 +1,152 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_element, unnecessary_cast
+
+part of 'progress_percentage_indicator_theme.dart';
+
+// **************************************************************************
+// TailorAnnotationsGenerator
+// **************************************************************************
+
+class ProgressPercentageIndicatorTheme extends ThemeExtension<ProgressPercentageIndicatorTheme> {
+  const ProgressPercentageIndicatorTheme({
+    required this.contentSpacing,
+    required this.percentageTextStyle,
+    required this.progressBarHeight,
+    required this.remainingSubtitleTextStyle,
+    required this.shimmerColor,
+    required this.subtitleTextStyle,
+    required this.timeRemainingTextStyle,
+    required this.titleTextStyle,
+  });
+
+  final double contentSpacing;
+  final TextStyle percentageTextStyle;
+  final double progressBarHeight;
+  final TextStyle remainingSubtitleTextStyle;
+  final Color shimmerColor;
+  final TextStyle subtitleTextStyle;
+  final TextStyle timeRemainingTextStyle;
+  final TextStyle titleTextStyle;
+
+  static final ProgressPercentageIndicatorTheme consumerLight = ProgressPercentageIndicatorTheme(
+    contentSpacing: _$ProgressPercentageIndicatorTheme.contentSpacing[0],
+    percentageTextStyle: _$ProgressPercentageIndicatorTheme.percentageTextStyle[0],
+    progressBarHeight: _$ProgressPercentageIndicatorTheme.progressBarHeight[0],
+    remainingSubtitleTextStyle: _$ProgressPercentageIndicatorTheme.remainingSubtitleTextStyle[0],
+    shimmerColor: _$ProgressPercentageIndicatorTheme.shimmerColor[0],
+    subtitleTextStyle: _$ProgressPercentageIndicatorTheme.subtitleTextStyle[0],
+    timeRemainingTextStyle: _$ProgressPercentageIndicatorTheme.timeRemainingTextStyle[0],
+    titleTextStyle: _$ProgressPercentageIndicatorTheme.titleTextStyle[0],
+  );
+
+  static final ProgressPercentageIndicatorTheme consumerDark = ProgressPercentageIndicatorTheme(
+    contentSpacing: _$ProgressPercentageIndicatorTheme.contentSpacing[1],
+    percentageTextStyle: _$ProgressPercentageIndicatorTheme.percentageTextStyle[1],
+    progressBarHeight: _$ProgressPercentageIndicatorTheme.progressBarHeight[1],
+    remainingSubtitleTextStyle: _$ProgressPercentageIndicatorTheme.remainingSubtitleTextStyle[1],
+    shimmerColor: _$ProgressPercentageIndicatorTheme.shimmerColor[1],
+    subtitleTextStyle: _$ProgressPercentageIndicatorTheme.subtitleTextStyle[1],
+    timeRemainingTextStyle: _$ProgressPercentageIndicatorTheme.timeRemainingTextStyle[1],
+    titleTextStyle: _$ProgressPercentageIndicatorTheme.titleTextStyle[1],
+  );
+
+  static final ProgressPercentageIndicatorTheme professionalLight = ProgressPercentageIndicatorTheme(
+    contentSpacing: _$ProgressPercentageIndicatorTheme.contentSpacing[2],
+    percentageTextStyle: _$ProgressPercentageIndicatorTheme.percentageTextStyle[2],
+    progressBarHeight: _$ProgressPercentageIndicatorTheme.progressBarHeight[2],
+    remainingSubtitleTextStyle: _$ProgressPercentageIndicatorTheme.remainingSubtitleTextStyle[2],
+    shimmerColor: _$ProgressPercentageIndicatorTheme.shimmerColor[2],
+    subtitleTextStyle: _$ProgressPercentageIndicatorTheme.subtitleTextStyle[2],
+    timeRemainingTextStyle: _$ProgressPercentageIndicatorTheme.timeRemainingTextStyle[2],
+    titleTextStyle: _$ProgressPercentageIndicatorTheme.titleTextStyle[2],
+  );
+
+  static final ProgressPercentageIndicatorTheme professionalDark = ProgressPercentageIndicatorTheme(
+    contentSpacing: _$ProgressPercentageIndicatorTheme.contentSpacing[3],
+    percentageTextStyle: _$ProgressPercentageIndicatorTheme.percentageTextStyle[3],
+    progressBarHeight: _$ProgressPercentageIndicatorTheme.progressBarHeight[3],
+    remainingSubtitleTextStyle: _$ProgressPercentageIndicatorTheme.remainingSubtitleTextStyle[3],
+    shimmerColor: _$ProgressPercentageIndicatorTheme.shimmerColor[3],
+    subtitleTextStyle: _$ProgressPercentageIndicatorTheme.subtitleTextStyle[3],
+    timeRemainingTextStyle: _$ProgressPercentageIndicatorTheme.timeRemainingTextStyle[3],
+    titleTextStyle: _$ProgressPercentageIndicatorTheme.titleTextStyle[3],
+  );
+
+  static final themes = [
+    consumerLight,
+    consumerDark,
+    professionalLight,
+    professionalDark,
+  ];
+
+  @override
+  ProgressPercentageIndicatorTheme copyWith({
+    double? contentSpacing,
+    TextStyle? percentageTextStyle,
+    double? progressBarHeight,
+    TextStyle? remainingSubtitleTextStyle,
+    Color? shimmerColor,
+    TextStyle? subtitleTextStyle,
+    TextStyle? timeRemainingTextStyle,
+    TextStyle? titleTextStyle,
+  }) {
+    return ProgressPercentageIndicatorTheme(
+      contentSpacing: contentSpacing ?? this.contentSpacing,
+      percentageTextStyle: percentageTextStyle ?? this.percentageTextStyle,
+      progressBarHeight: progressBarHeight ?? this.progressBarHeight,
+      remainingSubtitleTextStyle: remainingSubtitleTextStyle ?? this.remainingSubtitleTextStyle,
+      shimmerColor: shimmerColor ?? this.shimmerColor,
+      subtitleTextStyle: subtitleTextStyle ?? this.subtitleTextStyle,
+      timeRemainingTextStyle: timeRemainingTextStyle ?? this.timeRemainingTextStyle,
+      titleTextStyle: titleTextStyle ?? this.titleTextStyle,
+    );
+  }
+
+  @override
+  ProgressPercentageIndicatorTheme lerp(
+      covariant ThemeExtension<ProgressPercentageIndicatorTheme>? other, double t) {
+    if (other is! ProgressPercentageIndicatorTheme) return this as ProgressPercentageIndicatorTheme;
+    return ProgressPercentageIndicatorTheme(
+      contentSpacing: t < 0.5 ? contentSpacing : other.contentSpacing,
+      percentageTextStyle: TextStyle.lerp(percentageTextStyle, other.percentageTextStyle, t)!,
+      progressBarHeight: t < 0.5 ? progressBarHeight : other.progressBarHeight,
+      remainingSubtitleTextStyle:
+          TextStyle.lerp(remainingSubtitleTextStyle, other.remainingSubtitleTextStyle, t)!,
+      shimmerColor: Color.lerp(shimmerColor, other.shimmerColor, t)!,
+      subtitleTextStyle: TextStyle.lerp(subtitleTextStyle, other.subtitleTextStyle, t)!,
+      timeRemainingTextStyle: TextStyle.lerp(timeRemainingTextStyle, other.timeRemainingTextStyle, t)!,
+      titleTextStyle: TextStyle.lerp(titleTextStyle, other.titleTextStyle, t)!,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is ProgressPercentageIndicatorTheme &&
+            const DeepCollectionEquality().equals(contentSpacing, other.contentSpacing) &&
+            const DeepCollectionEquality().equals(percentageTextStyle, other.percentageTextStyle) &&
+            const DeepCollectionEquality().equals(progressBarHeight, other.progressBarHeight) &&
+            const DeepCollectionEquality().equals(remainingSubtitleTextStyle, other.remainingSubtitleTextStyle) &&
+            const DeepCollectionEquality().equals(shimmerColor, other.shimmerColor) &&
+            const DeepCollectionEquality().equals(subtitleTextStyle, other.subtitleTextStyle) &&
+            const DeepCollectionEquality().equals(timeRemainingTextStyle, other.timeRemainingTextStyle) &&
+            const DeepCollectionEquality().equals(titleTextStyle, other.titleTextStyle));
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      runtimeType.hashCode,
+      const DeepCollectionEquality().hash(contentSpacing),
+      const DeepCollectionEquality().hash(percentageTextStyle),
+      const DeepCollectionEquality().hash(progressBarHeight),
+      const DeepCollectionEquality().hash(remainingSubtitleTextStyle),
+      const DeepCollectionEquality().hash(shimmerColor),
+      const DeepCollectionEquality().hash(subtitleTextStyle),
+      const DeepCollectionEquality().hash(timeRemainingTextStyle),
+      const DeepCollectionEquality().hash(titleTextStyle),
+    );
+  }
+}

--- a/yggdrasil/lib/src/theme/progress_indicator/progress_indicator_theme.dart
+++ b/yggdrasil/lib/src/theme/progress_indicator/progress_indicator_theme.dart
@@ -12,4 +12,8 @@ class _$YgProgressIndicatorTheme {
 
   @themeExtension
   static final List<LinearProgressIndicatorTheme> linearProgressIndicatorTheme = LinearProgressIndicatorTheme.themes;
+
+  @themeExtension
+  static final List<ProgressPercentageIndicatorTheme> progressPercentageIndicatorTheme =
+      ProgressPercentageIndicatorTheme.themes;
 }

--- a/yggdrasil/lib/src/theme/progress_indicator/progress_indicator_theme.tailor.dart
+++ b/yggdrasil/lib/src/theme/progress_indicator/progress_indicator_theme.tailor.dart
@@ -12,29 +12,35 @@ class YgProgressIndicatorTheme extends ThemeExtension<YgProgressIndicatorTheme> 
   const YgProgressIndicatorTheme({
     required this.circularProgressIndicatorTheme,
     required this.linearProgressIndicatorTheme,
+    required this.progressPercentageIndicatorTheme,
   });
 
   final CircularProgressIndicatorTheme circularProgressIndicatorTheme;
   final LinearProgressIndicatorTheme linearProgressIndicatorTheme;
+  final ProgressPercentageIndicatorTheme progressPercentageIndicatorTheme;
 
   static final YgProgressIndicatorTheme consumerLight = YgProgressIndicatorTheme(
     circularProgressIndicatorTheme: _$YgProgressIndicatorTheme.circularProgressIndicatorTheme[0],
     linearProgressIndicatorTheme: _$YgProgressIndicatorTheme.linearProgressIndicatorTheme[0],
+    progressPercentageIndicatorTheme: _$YgProgressIndicatorTheme.progressPercentageIndicatorTheme[0],
   );
 
   static final YgProgressIndicatorTheme consumerDark = YgProgressIndicatorTheme(
     circularProgressIndicatorTheme: _$YgProgressIndicatorTheme.circularProgressIndicatorTheme[1],
     linearProgressIndicatorTheme: _$YgProgressIndicatorTheme.linearProgressIndicatorTheme[1],
+    progressPercentageIndicatorTheme: _$YgProgressIndicatorTheme.progressPercentageIndicatorTheme[1],
   );
 
   static final YgProgressIndicatorTheme professionalLight = YgProgressIndicatorTheme(
     circularProgressIndicatorTheme: _$YgProgressIndicatorTheme.circularProgressIndicatorTheme[2],
     linearProgressIndicatorTheme: _$YgProgressIndicatorTheme.linearProgressIndicatorTheme[2],
+    progressPercentageIndicatorTheme: _$YgProgressIndicatorTheme.progressPercentageIndicatorTheme[2],
   );
 
   static final YgProgressIndicatorTheme professionalDark = YgProgressIndicatorTheme(
     circularProgressIndicatorTheme: _$YgProgressIndicatorTheme.circularProgressIndicatorTheme[3],
     linearProgressIndicatorTheme: _$YgProgressIndicatorTheme.linearProgressIndicatorTheme[3],
+    progressPercentageIndicatorTheme: _$YgProgressIndicatorTheme.progressPercentageIndicatorTheme[3],
   );
 
   static final themes = [
@@ -48,10 +54,13 @@ class YgProgressIndicatorTheme extends ThemeExtension<YgProgressIndicatorTheme> 
   YgProgressIndicatorTheme copyWith({
     CircularProgressIndicatorTheme? circularProgressIndicatorTheme,
     LinearProgressIndicatorTheme? linearProgressIndicatorTheme,
+    ProgressPercentageIndicatorTheme? progressPercentageIndicatorTheme,
   }) {
     return YgProgressIndicatorTheme(
       circularProgressIndicatorTheme: circularProgressIndicatorTheme ?? this.circularProgressIndicatorTheme,
       linearProgressIndicatorTheme: linearProgressIndicatorTheme ?? this.linearProgressIndicatorTheme,
+      progressPercentageIndicatorTheme:
+          progressPercentageIndicatorTheme ?? this.progressPercentageIndicatorTheme,
     );
   }
 
@@ -64,6 +73,9 @@ class YgProgressIndicatorTheme extends ThemeExtension<YgProgressIndicatorTheme> 
               as CircularProgressIndicatorTheme,
       linearProgressIndicatorTheme:
           linearProgressIndicatorTheme.lerp(other.linearProgressIndicatorTheme, t) as LinearProgressIndicatorTheme,
+      progressPercentageIndicatorTheme:
+          progressPercentageIndicatorTheme.lerp(other.progressPercentageIndicatorTheme, t)
+              as ProgressPercentageIndicatorTheme,
     );
   }
 
@@ -76,7 +88,9 @@ class YgProgressIndicatorTheme extends ThemeExtension<YgProgressIndicatorTheme> 
               circularProgressIndicatorTheme,
               other.circularProgressIndicatorTheme,
             ) &&
-            const DeepCollectionEquality().equals(linearProgressIndicatorTheme, other.linearProgressIndicatorTheme));
+            const DeepCollectionEquality().equals(linearProgressIndicatorTheme, other.linearProgressIndicatorTheme) &&
+            const DeepCollectionEquality().equals(
+                progressPercentageIndicatorTheme, other.progressPercentageIndicatorTheme));
   }
 
   @override
@@ -85,6 +99,7 @@ class YgProgressIndicatorTheme extends ThemeExtension<YgProgressIndicatorTheme> 
       runtimeType.hashCode,
       const DeepCollectionEquality().hash(circularProgressIndicatorTheme),
       const DeepCollectionEquality().hash(linearProgressIndicatorTheme),
+      const DeepCollectionEquality().hash(progressPercentageIndicatorTheme),
     );
   }
 }

--- a/yggdrasil/lib/src/utils/yg_controller_manager/yg_controller_manager_implementation.dart
+++ b/yggdrasil/lib/src/utils/yg_controller_manager/yg_controller_manager_implementation.dart
@@ -24,7 +24,7 @@ class YgControllerManagerImplementation<T extends Listenable> implements YgContr
     }
 
     final T controller = _controller;
-    final VoidCallback? listener = this._listener;
+    final VoidCallback? listener = _listener;
     if (listener != null) {
       controller.addListener(listener);
     }
@@ -72,7 +72,7 @@ class YgControllerManagerImplementation<T extends Listenable> implements YgContr
   }
 
   void _updateController(T newController) {
-    final VoidCallback? listener = this._listener;
+    final VoidCallback? listener = _listener;
     final T controller = _controller;
     if (controller is YgAttachable && _attached) {
       controller.detach();
@@ -93,7 +93,7 @@ class YgControllerManagerImplementation<T extends Listenable> implements YgContr
   }
 
   void dispose() {
-    final VoidCallback? listener = this._listener;
+    final VoidCallback? listener = _listener;
     final T controller = _controller;
     if (listener != null) {
       controller.removeListener(listener);


### PR DESCRIPTION
# Checklist

- [ ] Self review has been performed.
- [ ] PR description contains information about what's new using valid PR tags.
- [ ] Add video with happy path or screenshot.

# Changes

[feature] Added `YgProgressPercentageIndicator` — a composite progress component that displays:
  - Large percentage text (e.g. "67 %")
  - Time remaining with subtitle (e.g. "~59 sec remaining")
  - Optional title (e.g. "Uploading files") and subtitle (e.g. "142 of 212 MB")
  - Thicker linear progress bar (2x the standard `YgLinearProgressIndicator` height)
  - Smooth 500ms animated transition between progress values (no jumps on infrequent updates)
  - Animated shimmer overlay on the filled portion of the progress bar (`isAnimated: true` by default)
[feature] Added `ProgressPercentageIndicatorTheme` with full theming support for all text styles, shimmer color, progress bar height, and content spacing across all 4 theme variants (consumer light/dark, professional light/dark).
