### PR TITLE
Kamil/siso 1853 add bottom bar

### DIFF
--- a/demo_app/lib/screens/_screens.dart
+++ b/demo_app/lib/screens/_screens.dart
@@ -3,6 +3,7 @@ export 'app_bar_sliver/_app_bar_sliver.dart';
 export 'avatar/_avatar.dart';
 export 'avatar_stack/_avatar_stack.dart';
 export 'badge/_badge.dart';
+export 'bottom_navigation_bar/_bottom_navigation_bar.dart';
 export 'bottom_sheet/_bottom_sheet.dart';
 export 'button/_button.dart';
 export 'button_group/_button_group.dart';

--- a/demo_app/lib/screens/bottom_navigation_bar/_bottom_navigation_bar.dart
+++ b/demo_app/lib/screens/bottom_navigation_bar/_bottom_navigation_bar.dart
@@ -1,0 +1,1 @@
+export 'bottom_navigation_bar_screen.dart';

--- a/demo_app/lib/screens/bottom_navigation_bar/bottom_navigation_bar_screen.dart
+++ b/demo_app/lib/screens/bottom_navigation_bar/bottom_navigation_bar_screen.dart
@@ -1,0 +1,341 @@
+import 'package:flutter/material.dart';
+import 'package:yggdrasil/yggdrasil.dart';
+import 'package:yggdrasil_demo/core/_core.dart';
+import 'package:yggdrasil_demo/widgets/_widgets.dart';
+
+class BottomNavigationBarScreen extends StatefulWidget {
+  const BottomNavigationBarScreen({super.key});
+
+  static const String routeName = 'BottomNavigationBarScreen';
+
+  static PageRouteBuilder<Widget> route() {
+    return const YgRouteBuilder().fadeTransition(
+      settings: const RouteSettings(name: routeName),
+      screen: const BottomNavigationBarScreen(),
+    );
+  }
+
+  @override
+  State<BottomNavigationBarScreen> createState() => _BottomNavigationBarScreenState();
+}
+
+class _BottomNavigationBarScreenState extends State<BottomNavigationBarScreen> {
+  int _fourIndex = 0;
+  int _fiveIndex = 2;
+  int _subtitleIndex = 1;
+  int _liveIndex = 0;
+  bool _showSubtitle = true;
+
+  static const List<YgBottomNavigationBarItem> _baseFourItems = <YgBottomNavigationBarItem>[
+    YgBottomNavigationBarItem(icon: YgIcons.homeMorning, title: 'Home'),
+    YgBottomNavigationBarItem(icon: YgIcons.search, title: 'Discover'),
+    YgBottomNavigationBarItem(icon: YgIcons.notification, title: 'Alerts'),
+    YgBottomNavigationBarItem(icon: YgIcons.settings, title: 'Settings'),
+  ];
+
+  static const List<YgBottomNavigationBarItem> _fiveItems = <YgBottomNavigationBarItem>[
+    YgBottomNavigationBarItem(icon: YgIcons.homeMorning, title: 'Home'),
+    YgBottomNavigationBarItem(icon: YgIcons.search, title: 'Discover'),
+    YgBottomNavigationBarItem(icon: YgIcons.calendar, title: 'Calendar'),
+    YgBottomNavigationBarItem(icon: YgIcons.notification, title: 'Alerts'),
+    YgBottomNavigationBarItem(icon: YgIcons.settings, title: 'Settings'),
+  ];
+
+  static const List<YgBottomNavigationBarItem> _subtitleItems = <YgBottomNavigationBarItem>[
+    YgBottomNavigationBarItem(
+      icon: YgIcons.homeMorning,
+      title: 'Home',
+      subtitle: '3 devices',
+    ),
+    YgBottomNavigationBarItem(
+      icon: YgIcons.calendar,
+      title: 'Calendar',
+      subtitle: '2 events',
+    ),
+    YgBottomNavigationBarItem(
+      icon: YgIcons.notification,
+      title: 'Alerts',
+      subtitle: '12 new',
+    ),
+    YgBottomNavigationBarItem(
+      icon: YgIcons.settings,
+      title: 'Settings',
+      subtitle: 'Up to date',
+    ),
+  ];
+
+  /// Pool of items used for the live demo. The user adds and removes items
+  /// from the middle of [_liveItems], drawing from items that are not already
+  /// present in the bar.
+  static const List<YgBottomNavigationBarItem> _candidatePool = <YgBottomNavigationBarItem>[
+    YgBottomNavigationBarItem(
+      icon: YgIcons.calendar,
+      title: 'Calendar',
+      subtitle: '2 events',
+    ),
+    YgBottomNavigationBarItem(
+      icon: YgIcons.bluetooth,
+      title: 'Devices',
+      subtitle: '6 paired',
+    ),
+    YgBottomNavigationBarItem(
+      icon: YgIcons.info,
+      title: 'About',
+      subtitle: 'v1.0',
+    ),
+    YgBottomNavigationBarItem(
+      icon: YgIcons.edit,
+      title: 'Notes',
+      subtitle: 'Drafts',
+    ),
+  ];
+
+  /// Initial set of items shown in the live demo bar.
+  late List<YgBottomNavigationBarItem> _liveItems = <YgBottomNavigationBarItem>[
+    const YgBottomNavigationBarItem(
+      icon: YgIcons.homeMorning,
+      title: 'Home',
+      subtitle: '3 devices',
+    ),
+    const YgBottomNavigationBarItem(
+      icon: YgIcons.search,
+      title: 'Discover',
+      subtitle: 'New picks',
+    ),
+    const YgBottomNavigationBarItem(
+      icon: YgIcons.notification,
+      title: 'Alerts',
+      subtitle: '12 new',
+    ),
+    const YgBottomNavigationBarItem(
+      icon: YgIcons.settings,
+      title: 'Settings',
+      subtitle: 'Up to date',
+    ),
+  ];
+
+  static const int _maxItems = 6;
+  static const int _minItems = 2;
+
+  YgBottomNavigationBarItem? _nextCandidate() {
+    final Set<String> existing = _liveItems.map((YgBottomNavigationBarItem i) => i.title).toSet();
+    for (final YgBottomNavigationBarItem candidate in _candidatePool) {
+      if (!existing.contains(candidate.title)) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  void _addItemInMiddle() {
+    if (_liveItems.length >= _maxItems) {
+      return;
+    }
+    final YgBottomNavigationBarItem? candidate = _nextCandidate();
+    if (candidate == null) {
+      return;
+    }
+    setState(() {
+      final int insertAt = _liveItems.length ~/ 2;
+      _liveItems = <YgBottomNavigationBarItem>[
+        ..._liveItems.sublist(0, insertAt),
+        candidate,
+        ..._liveItems.sublist(insertAt),
+      ];
+      // Keep selection on the same logical item it was on before the insert.
+      if (_liveIndex >= insertAt) {
+        _liveIndex += 1;
+      }
+    });
+  }
+
+  void _removeItemFromMiddle() {
+    if (_liveItems.length <= _minItems) {
+      return;
+    }
+    setState(() {
+      final int removeAt = (_liveItems.length - 1) ~/ 2;
+      _liveItems = <YgBottomNavigationBarItem>[
+        ..._liveItems.sublist(0, removeAt),
+        ..._liveItems.sublist(removeAt + 1),
+      ];
+      if (_liveIndex == removeAt) {
+        _liveIndex = (removeAt - 1).clamp(0, _liveItems.length - 1);
+      } else if (_liveIndex > removeAt) {
+        _liveIndex -= 1;
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final bool canAdd = _liveItems.length < _maxItems && _nextCandidate() != null;
+    final bool canRemove = _liveItems.length > _minItems;
+
+    return DemoScreen(
+      componentName: 'BottomNavigationBar',
+      child: YgLayoutBody(
+        child: Column(
+          children: <Widget>[
+            YgSection.column(
+              title: '4 items',
+              subtitle: 'Default usage with icon and title only.',
+              children: <Widget>[
+                YgBottomNavigationBar(
+                  items: _baseFourItems,
+                  currentIndex: _fourIndex,
+                  applySafeArea: false,
+                  onTap: (int index) => setState(() => _fourIndex = index),
+                ),
+              ],
+            ),
+            YgSection.column(
+              title: '5 items',
+              subtitle: 'Indicator slides between items as the selection changes.',
+              children: <Widget>[
+                YgBottomNavigationBar(
+                  items: _fiveItems,
+                  currentIndex: _fiveIndex,
+                  applySafeArea: false,
+                  onTap: (int index) => setState(() => _fiveIndex = index),
+                ),
+              ],
+            ),
+            YgSection.column(
+              title: 'With subtitle',
+              subtitle: 'Each item exposes an optional subtitle, toggled per bar.',
+              children: <Widget>[
+                YgBottomNavigationBar(
+                  items: _subtitleItems,
+                  currentIndex: _subtitleIndex,
+                  showSubtitle: true,
+                  applySafeArea: false,
+                  onTap: (int index) => setState(() => _subtitleIndex = index),
+                ),
+              ],
+            ),
+            YgSection.column(
+              title: 'Live: insert and remove items in the middle',
+              subtitle:
+                  'Use the + / − buttons to inject or remove a tile in the middle of the bar. '
+                  'Existing tiles smoothly resize to make room (or close the gap), and inserted '
+                  'tiles fade in.',
+              children: <Widget>[
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 8,
+                  children: <Widget>[
+                    YgButton(
+                      onPressed: canAdd ? _addItemInMiddle : null,
+                      child: const Text('+ Insert in middle'),
+                    ),
+                    YgButton(
+                      variant: YgButtonVariant.secondary,
+                      onPressed: canRemove ? _removeItemFromMiddle : null,
+                      child: const Text('− Remove from middle'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: <Widget>[
+                    const Text('Show subtitle'),
+                    const SizedBox(width: 8),
+                    YgSwitch(
+                      value: _showSubtitle,
+                      onChanged: (bool value) => setState(() => _showSubtitle = value),
+                    ),
+                    const SizedBox(width: 16),
+                    Text('Items: ${_liveItems.length}'),
+                  ],
+                ),
+                const SizedBox(height: 12),
+                YgBottomNavigationBar(
+                  items: _liveItems,
+                  currentIndex: _liveIndex.clamp(0, _liveItems.length - 1),
+                  showSubtitle: _showSubtitle,
+                  applySafeArea: false,
+                  onTap: (int index) => setState(() => _liveIndex = index),
+                ),
+              ],
+            ),
+            YgSection.column(
+              title: 'Safe area',
+              subtitle:
+                  'When the bar is placed directly above the bottom of the screen, leave applySafeArea: true (the default). '
+                  'When wrapped in a parent that already pads the bottom inset (e.g. YgLayoutBody.footer), pass '
+                  'applySafeArea: false so the safe area is not consumed twice.',
+              children: <Widget>[
+                YgButton(
+                  onPressed: () => sl<YgRouter>().push(_BottomNavigationBarFullScreenDemo.route()),
+                  child: const Text('Open full-screen demo'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Full-screen demo of [YgBottomNavigationBar] used as a sticky footer of
+/// [YgLayoutBody]. The bar is rendered with `applySafeArea: false` because
+/// the layout body already pads the bottom inset.
+class _BottomNavigationBarFullScreenDemo extends StatefulWidget {
+  const _BottomNavigationBarFullScreenDemo();
+
+  static const String routeName = 'BottomNavigationBarFullScreenDemo';
+
+  static PageRouteBuilder<Widget> route() {
+    return const YgRouteBuilder().fadeTransition(
+      settings: const RouteSettings(name: routeName),
+      screen: const _BottomNavigationBarFullScreenDemo(),
+    );
+  }
+
+  @override
+  State<_BottomNavigationBarFullScreenDemo> createState() => _BottomNavigationBarFullScreenDemoState();
+}
+
+class _BottomNavigationBarFullScreenDemoState extends State<_BottomNavigationBarFullScreenDemo> {
+  static const List<YgBottomNavigationBarItem> _tabs = <YgBottomNavigationBarItem>[
+    YgBottomNavigationBarItem(icon: YgIcons.homeMorning, title: 'Home'),
+    YgBottomNavigationBarItem(icon: YgIcons.search, title: 'Discover'),
+    YgBottomNavigationBarItem(icon: YgIcons.notification, title: 'Alerts'),
+    YgBottomNavigationBarItem(icon: YgIcons.settings, title: 'Settings'),
+  ];
+
+  int _index = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return DemoScreen(
+      componentName: 'BottomNavigationBar — full screen',
+      child: YgLayoutBody(
+        footer: YgBottomNavigationBar(
+          items: _tabs,
+          currentIndex: _index,
+          applySafeArea: false,
+          onTap: (int index) => setState(() => _index = index),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text(
+                'Selected tab: ${_tabs[_index].title}',
+              ),
+              const SizedBox(height: 12),
+              const Text(
+                'YgLayoutBody.footer pads the bottom inset itself, so the bar '
+                'is rendered with applySafeArea: false to avoid double padding.',
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/demo_app/lib/screens/bottom_navigation_bar/bottom_navigation_bar_screen.dart
+++ b/demo_app/lib/screens/bottom_navigation_bar/bottom_navigation_bar_screen.dart
@@ -262,8 +262,11 @@ class _BottomNavigationBarScreenState extends State<BottomNavigationBarScreen> {
             YgSection.column(
               title: 'Safe area',
               subtitle:
-                  'When the bar is placed directly above the bottom of the screen, leave applySafeArea: true (the default). '
-                  'When wrapped in a parent that already pads the bottom inset (e.g. YgLayoutBody.footer), pass '
+                  'For full-screen usage, pass the bar to YgLayout.bottomNavigationBar — '
+                  'the layout reserves space and strips the bottom inset from the content '
+                  'so the bar owns the safe area (applySafeArea defaults to true). '
+                  'When embedding the bar inside a parent that already pads the bottom '
+                  'inset (e.g. YgLayoutBody.footer or another navigation bar slot), set '
                   'applySafeArea: false so the safe area is not consumed twice.',
               children: <Widget>[
                 YgButton(
@@ -279,9 +282,11 @@ class _BottomNavigationBarScreenState extends State<BottomNavigationBarScreen> {
   }
 }
 
-/// Full-screen demo of [YgBottomNavigationBar] used as a sticky footer of
-/// [YgLayoutBody]. The bar is rendered with `applySafeArea: false` because
-/// the layout body already pads the bottom inset.
+/// Full-screen demo using [YgLayout]'s `bottomNavigationBar` slot — the bar
+/// sits at the bottom of the screen and the layout reserves vertical space
+/// for it. The bar handles its own safe area (default `applySafeArea: true`)
+/// because [YgLayout] strips the bottom inset from the content's MediaQuery
+/// before passing it down.
 class _BottomNavigationBarFullScreenDemo extends StatefulWidget {
   const _BottomNavigationBarFullScreenDemo();
 
@@ -312,13 +317,12 @@ class _BottomNavigationBarFullScreenDemoState extends State<_BottomNavigationBar
   Widget build(BuildContext context) {
     return DemoScreen(
       componentName: 'BottomNavigationBar — full screen',
+      bottomNavigationBar: YgBottomNavigationBar(
+        items: _tabs,
+        currentIndex: _index,
+        onTap: (int index) => setState(() => _index = index),
+      ),
       child: YgLayoutBody(
-        footer: YgBottomNavigationBar(
-          items: _tabs,
-          currentIndex: _index,
-          applySafeArea: false,
-          onTap: (int index) => setState(() => _index = index),
-        ),
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Column(
@@ -329,8 +333,9 @@ class _BottomNavigationBarFullScreenDemoState extends State<_BottomNavigationBar
               ),
               const SizedBox(height: 12),
               const Text(
-                'YgLayoutBody.footer pads the bottom inset itself, so the bar '
-                'is rendered with applySafeArea: false to avoid double padding.',
+                'YgLayout.bottomNavigationBar pins the bar to the bottom and '
+                'strips the bottom inset from the content, so the bar handles '
+                'safe area by itself.',
               ),
             ],
           ),

--- a/demo_app/lib/screens/home_screen.dart
+++ b/demo_app/lib/screens/home_screen.dart
@@ -62,6 +62,11 @@ class HomeScreen extends StatelessWidget {
                       trailingWidgets: const <YgIcon>[YgIcon(YgIcons.caretRight)],
                     ),
                     YgListTile(
+                      title: 'BottomNavigationBar',
+                      onTap: () => sl<YgRouter>().push(BottomNavigationBarScreen.route()),
+                      trailingWidgets: const <YgIcon>[YgIcon(YgIcons.caretRight)],
+                    ),
+                    YgListTile(
                       title: 'BottomSheet',
                       onTap: () => sl<YgRouter>().push(BottomSheetScreen.route()),
                       trailingWidgets: const <YgIcon>[YgIcon(YgIcons.caretRight)],

--- a/demo_app/lib/widgets/demo_screen/demo_screen.dart
+++ b/demo_app/lib/widgets/demo_screen/demo_screen.dart
@@ -12,6 +12,7 @@ abstract class DemoScreen extends StatelessWidget {
     Key? key,
     required Widget child,
     Widget? appBar,
+    Widget? bottomNavigationBar,
     String? componentName,
     YgHeaderBehavior headerBehavior,
   }) = _DemoScreenRegular;
@@ -20,6 +21,7 @@ abstract class DemoScreen extends StatelessWidget {
     Key? key,
     required List<YgLayoutTab> tabs,
     Widget? appBar,
+    Widget? bottomNavigationBar,
     String? componentName,
     YgHeaderBehavior headerBehavior,
   }) = _DemoScreenTabbed;
@@ -28,12 +30,14 @@ abstract class DemoScreen extends StatelessWidget {
     super.key,
     this.componentName,
     this.appBar,
+    this.bottomNavigationBar,
     this.headerBehavior = YgHeaderBehavior.fixed,
   }) : assert(componentName != null || appBar != null, 'Either componentName or appBar must be provided.');
 
   final YgHeaderBehavior headerBehavior;
   final String? componentName;
   final Widget? appBar;
+  final Widget? bottomNavigationBar;
 
   @override
   Widget build(BuildContext context) {

--- a/demo_app/lib/widgets/demo_screen/demo_screen_regular.dart
+++ b/demo_app/lib/widgets/demo_screen/demo_screen_regular.dart
@@ -5,6 +5,7 @@ class _DemoScreenRegular extends DemoScreen {
     super.key,
     required this.child,
     super.appBar,
+    super.bottomNavigationBar,
     super.componentName,
     super.headerBehavior,
   }) : super._();
@@ -16,6 +17,7 @@ class _DemoScreenRegular extends DemoScreen {
     return YgLayout(
       headerBehavior: headerBehavior,
       appBar: appBar,
+      bottomNavigationBar: bottomNavigationBar,
       child: child,
     );
   }

--- a/demo_app/lib/widgets/demo_screen/demo_screen_tabbed.dart
+++ b/demo_app/lib/widgets/demo_screen/demo_screen_tabbed.dart
@@ -5,6 +5,7 @@ class _DemoScreenTabbed extends DemoScreen {
     super.key,
     required this.tabs,
     super.appBar,
+    super.bottomNavigationBar,
     super.componentName,
     super.headerBehavior,
   }) : super._();
@@ -16,6 +17,7 @@ class _DemoScreenTabbed extends DemoScreen {
     return YgLayout.tabbed(
       headerBehavior: headerBehavior,
       appBar: appBar,
+      bottomNavigationBar: bottomNavigationBar,
       tabs: tabs,
     );
   }

--- a/yggdrasil/lib/src/components/_components.dart
+++ b/yggdrasil/lib/src/components/_components.dart
@@ -3,6 +3,7 @@ export 'fields/_fields.dart';
 export 'yg_app_bar/_yg_app_bar.dart';
 export 'yg_avatar_stack/_yg_avatar_stack.dart';
 export 'yg_badge/_yg_badge.dart';
+export 'yg_bottom_navigation_bar/_yg_bottom_navigation_bar.dart';
 export 'yg_bottom_sheet/_yg_bottom_sheet.dart';
 export 'yg_button_group/_yg_button_group.dart';
 export 'yg_callout/_yg_callout.dart';

--- a/yggdrasil/lib/src/components/yg_bottom_navigation_bar/_yg_bottom_navigation_bar.dart
+++ b/yggdrasil/lib/src/components/yg_bottom_navigation_bar/_yg_bottom_navigation_bar.dart
@@ -1,0 +1,2 @@
+export 'yg_bottom_navigation_bar.dart';
+export 'yg_bottom_navigation_bar_item.dart';

--- a/yggdrasil/lib/src/components/yg_bottom_navigation_bar/yg_bottom_navigation_bar.dart
+++ b/yggdrasil/lib/src/components/yg_bottom_navigation_bar/yg_bottom_navigation_bar.dart
@@ -1,0 +1,295 @@
+import 'package:flutter/material.dart';
+import 'package:yggdrasil/src/components/yg_icon/_yg_icon.dart';
+import 'package:yggdrasil/src/theme/_theme.dart';
+import 'package:yggdrasil/src/utils/yg_debug/_yg_debug.dart';
+
+import 'yg_bottom_navigation_bar_item.dart';
+
+/// A bottom navigation bar showing a configurable number of items.
+///
+/// Each item shows an icon, a title, and optionally a subtitle. The currently
+/// selected item is highlighted with an animated indicator that slides between
+/// items as the selection changes. Items are positioned with [AnimatedPositioned]
+/// in a stack so that adding or removing an item — including in the middle of
+/// the list — smoothly resizes and reflows the remaining items. Newly inserted
+/// items fade in.
+///
+/// Items are matched across rebuilds by [YgBottomNavigationBarItem.title], so
+/// titles must be unique within a single bar for the layout animation to track
+/// items correctly.
+///
+/// Safe area handling
+/// ------------------
+/// By default, the bar applies bottom [SafeArea] padding so it can be used
+/// directly as the bottom widget of a screen. When the parent already handles
+/// the bottom safe area (e.g. [YgLayoutBody]'s `footer` slot or any other
+/// slot in [YgLayout] that pads for the bottom inset), set [applySafeArea] to
+/// false to avoid padding the bar twice.
+class YgBottomNavigationBar extends StatelessWidget with StatelessWidgetDebugMixin {
+  const YgBottomNavigationBar({
+    super.key,
+    required this.items,
+    required this.currentIndex,
+    required this.onTap,
+    this.showSubtitle = false,
+    this.applySafeArea = true,
+  }) : assert(items.length > 0, 'YgBottomNavigationBar requires at least one item'),
+       assert(
+         currentIndex >= 0 && currentIndex < items.length,
+         'currentIndex must be within the items range',
+       );
+
+  /// The items shown inside of the bar.
+  ///
+  /// Typically 3 to 5 items. Items must have unique [YgBottomNavigationBarItem.title]
+  /// values within a single bar so that insertion/removal animations can track
+  /// them correctly.
+  final List<YgBottomNavigationBarItem> items;
+
+  /// The index of the currently selected item.
+  final int currentIndex;
+
+  /// Called when an item is tapped, providing the index of the tapped item.
+  final ValueChanged<int> onTap;
+
+  /// Whether to show the optional [YgBottomNavigationBarItem.subtitle] below
+  /// the title.
+  final bool showSubtitle;
+
+  /// Whether the bar should pad itself for the bottom safe area.
+  ///
+  /// Set to `false` when the bar is wrapped by a parent that already handles
+  /// the bottom inset, so the safe area is not consumed twice.
+  final bool applySafeArea;
+
+  @override
+  Widget build(BuildContext context) {
+    assert(() {
+      final Set<String> seen = <String>{};
+      for (final YgBottomNavigationBarItem item in items) {
+        if (!seen.add(item.title)) {
+          throw FlutterError(
+            'YgBottomNavigationBar items must have unique titles — '
+            'titles are used as keys for layout animations. '
+            'Duplicate title: "${item.title}".',
+          );
+        }
+      }
+      return true;
+    }());
+
+    final YgBottomNavigationBarTheme theme = context.bottomNavigationBarTheme;
+
+    Widget content = Material(
+      type: MaterialType.transparency,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.backgroundColor,
+          border: Border(
+            top: BorderSide(
+              color: theme.dividerColor,
+              width: theme.dividerHeight,
+            ),
+          ),
+        ),
+        child: LayoutBuilder(
+          builder: (BuildContext context, BoxConstraints constraints) {
+            final double totalWidth = constraints.maxWidth;
+            final double itemWidth = totalWidth / items.length;
+            return SizedBox(
+              width: totalWidth,
+              child: IntrinsicHeight(
+                child: Stack(
+                  children: <Widget>[
+                    // Invisible reference row that drives the intrinsic height
+                    // of the bar so the [Stack] can size itself even though all
+                    // visible items are absolutely positioned.
+                    IgnorePointer(
+                      child: Visibility(
+                        visible: false,
+                        maintainSize: true,
+                        maintainAnimation: true,
+                        maintainState: true,
+                        child: Row(
+                          children: <Widget>[
+                            for (final YgBottomNavigationBarItem item in items)
+                              Expanded(
+                                child: _Item(
+                                  item: item,
+                                  selected: false,
+                                  showSubtitle: showSubtitle,
+                                  onTap: null,
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    AnimatedPositioned(
+                      duration: theme.animationDuration,
+                      curve: theme.animationCurve,
+                      top: 0,
+                      left: currentIndex * itemWidth,
+                      width: itemWidth,
+                      height: theme.indicatorHeight,
+                      child: IgnorePointer(
+                        child: DecoratedBox(
+                          decoration: BoxDecoration(
+                            color: theme.indicatorColor,
+                            borderRadius: theme.indicatorRadius,
+                          ),
+                        ),
+                      ),
+                    ),
+                    for (int i = 0; i < items.length; i++)
+                      AnimatedPositioned(
+                        key: ValueKey<String>(items[i].title),
+                        duration: theme.animationDuration,
+                        curve: theme.animationCurve,
+                        left: i * itemWidth,
+                        top: 0,
+                        bottom: 0,
+                        width: itemWidth,
+                        child: _AppearingItem(
+                          duration: theme.animationDuration,
+                          curve: theme.animationCurve,
+                          child: _Item(
+                            item: items[i],
+                            selected: i == currentIndex,
+                            showSubtitle: showSubtitle,
+                            onTap: () => onTap(i),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+
+    if (applySafeArea) {
+      content = SafeArea(
+        top: false,
+        child: content,
+      );
+    }
+
+    return content;
+  }
+
+  @override
+  YgDebugType get debugType => YgDebugType.layout;
+}
+
+/// Fades a newly inserted item in from 0 → 1 on its first build.
+///
+/// Items that are simply rebuilt (existing items with the same key) keep the
+/// internal [TweenAnimationBuilder] state, so they do not re-animate.
+class _AppearingItem extends StatelessWidget {
+  const _AppearingItem({
+    required this.duration,
+    required this.curve,
+    required this.child,
+  });
+
+  final Duration duration;
+  final Curve curve;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return TweenAnimationBuilder<double>(
+      tween: Tween<double>(begin: 0.0, end: 1.0),
+      duration: duration,
+      curve: curve,
+      builder: (BuildContext context, double value, Widget? child) {
+        return Opacity(
+          opacity: value,
+          child: child,
+        );
+      },
+      child: child,
+    );
+  }
+}
+
+class _Item extends StatelessWidget {
+  const _Item({
+    required this.item,
+    required this.selected,
+    required this.showSubtitle,
+    required this.onTap,
+  });
+
+  final YgBottomNavigationBarItem item;
+  final bool selected;
+  final bool showSubtitle;
+
+  /// `null` when the item is being rendered for layout-measurement only
+  /// (the invisible reference row inside the bar) and shouldn't be interactive.
+  final VoidCallback? onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final YgBottomNavigationBarTheme theme = context.bottomNavigationBarTheme;
+    final String? subtitle = item.subtitle;
+
+    final Color iconColor = selected ? theme.selectedIconColor : theme.unselectedIconColor;
+    final TextStyle titleStyle = selected ? theme.selectedTitleTextStyle : theme.unselectedTitleTextStyle;
+    final TextStyle subtitleStyle = selected ? theme.selectedSubtitleTextStyle : theme.unselectedSubtitleTextStyle;
+
+    return InkWell(
+      onTap: onTap,
+      hoverColor: theme.hoverBackgroundColor,
+      splashColor: theme.pressedBackgroundColor,
+      child: Padding(
+        padding: theme.itemPadding,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: <Widget>[
+            TweenAnimationBuilder<Color?>(
+              tween: ColorTween(end: iconColor),
+              duration: theme.animationDuration,
+              curve: theme.animationCurve,
+              builder: (BuildContext context, Color? animatedColor, Widget? _) {
+                return IconTheme(
+                  data: IconThemeData(color: animatedColor),
+                  child: YgIcon(
+                    item.icon,
+                    size: YgIconSize.small,
+                  ),
+                );
+              },
+            ),
+            SizedBox(height: theme.iconLabelSpacing),
+            AnimatedDefaultTextStyle(
+              duration: theme.animationDuration,
+              curve: theme.animationCurve,
+              style: titleStyle,
+              textAlign: TextAlign.center,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              child: Text(item.title),
+            ),
+            if (showSubtitle && subtitle != null) ...<Widget>[
+              SizedBox(height: theme.titleSubtitleSpacing),
+              AnimatedDefaultTextStyle(
+                duration: theme.animationDuration,
+                curve: theme.animationCurve,
+                style: subtitleStyle,
+                textAlign: TextAlign.center,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                child: Text(subtitle),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/yggdrasil/lib/src/components/yg_bottom_navigation_bar/yg_bottom_navigation_bar.dart
+++ b/yggdrasil/lib/src/components/yg_bottom_navigation_bar/yg_bottom_navigation_bar.dart
@@ -21,9 +21,13 @@ import 'yg_bottom_navigation_bar_item.dart';
 /// Safe area handling
 /// ------------------
 /// By default, the bar applies bottom [SafeArea] padding so it can be used
-/// directly as the bottom widget of a screen. When the parent already handles
-/// the bottom safe area (e.g. [YgLayoutBody]'s `footer` slot or any other
-/// slot in [YgLayout] that pads for the bottom inset), set [applySafeArea] to
+/// directly as the bottom widget of a screen — including the recommended
+/// pattern of passing it to [YgLayout]'s `bottomNavigationBar` slot. The
+/// layout reserves vertical space for the bar and strips the bottom inset
+/// from the content's [MediaQuery], leaving the bar to own the safe area.
+///
+/// When the bar is wrapped in a parent that *already* pads the bottom inset
+/// itself (e.g. [YgLayoutBody]'s `footer` slot), set [applySafeArea] to
 /// false to avoid padding the bar twice.
 class YgBottomNavigationBar extends StatelessWidget with StatelessWidgetDebugMixin {
   const YgBottomNavigationBar({

--- a/yggdrasil/lib/src/components/yg_bottom_navigation_bar/yg_bottom_navigation_bar_item.dart
+++ b/yggdrasil/lib/src/components/yg_bottom_navigation_bar/yg_bottom_navigation_bar_item.dart
@@ -1,0 +1,22 @@
+import 'package:yggdrasil/src/utils/yg_icon_data/yg_icon_data.dart';
+
+/// A single item shown inside of a [YgBottomNavigationBar].
+class YgBottomNavigationBarItem {
+  const YgBottomNavigationBarItem({
+    required this.icon,
+    required this.title,
+    this.subtitle,
+  });
+
+  /// The icon shown above the title.
+  final YgIconData icon;
+
+  /// The label shown below the icon.
+  final String title;
+
+  /// Optional secondary label shown below the [title].
+  ///
+  /// Only displayed when the parent [YgBottomNavigationBar] has
+  /// `showSubtitle` enabled.
+  final String? subtitle;
+}

--- a/yggdrasil/lib/src/components/yg_layout/layout/widgets/layout_header_renderer/yg_layout_header_render_widget.dart
+++ b/yggdrasil/lib/src/components/yg_layout/layout/widgets/layout_header_renderer/yg_layout_header_render_widget.dart
@@ -326,12 +326,19 @@ class YgLayoutHeaderRenderer extends RenderBox
   @override
   void attach(PipelineOwner owner) {
     super.attach(owner);
-    _controller.addListener(markNeedsLayout);
+    // Controller updates only affect paint-time positioning (children's
+    // parentData.offset is set inside [paint], never inside [performLayout]),
+    // so a paint invalidation is sufficient. Using [markNeedsLayout] here
+    // crashed when the controller fired notifications while an unrelated
+    // render tree (e.g. a sliver mounting a child) was actively laying out,
+    // since [markNeedsLayout] is restricted to descendants of the active
+    // layout. [markNeedsPaint] has no such restriction.
+    _controller.addListener(markNeedsPaint);
   }
 
   @override
   void detach() {
-    _controller.removeListener(markNeedsLayout);
+    _controller.removeListener(markNeedsPaint);
     super.detach();
   }
 

--- a/yggdrasil/lib/src/components/yg_layout/layout/widgets/yg_layout_internal/yg_layout_internal.dart
+++ b/yggdrasil/lib/src/components/yg_layout/layout/widgets/yg_layout_internal/yg_layout_internal.dart
@@ -16,6 +16,7 @@ class YgLayoutInternal extends StatelessWidget {
     required this.headerBehavior,
     this.appBar,
     this.bottom,
+    this.bottomNavigationBar,
   });
 
   /// The content shown in the layout.
@@ -26,6 +27,13 @@ class YgLayoutInternal extends StatelessWidget {
 
   /// The widget shown bellow the [appBar].
   final Widget? bottom;
+
+  /// Widget pinned to the bottom of the screen (e.g. a bottom navigation bar).
+  ///
+  /// When non-null, this widget receives the bottom inset from the original
+  /// [MediaQuery] (so it can pad itself for the safe area), while the [content]
+  /// has its bottom inset stripped so it does not double-pad.
+  final Widget? bottomNavigationBar;
 
   /// The controller responsible for animating the header.
   final YgLayoutHeaderController controller;
@@ -39,42 +47,68 @@ class YgLayoutInternal extends StatelessWidget {
 
     final Widget? appBar = this.appBar;
     final Widget? bottom = this.bottom;
+    final Widget? bottomNavigationBar = this.bottomNavigationBar;
+
+    Widget contentArea = YgLayoutRenderWidget(
+      children: <Widget>[
+        content,
+        MediaQuery.removePadding(
+          removeTop: true,
+          context: context,
+          child: YgLayoutHeaderRenderWidget(
+            padding: MediaQuery.paddingOf(context),
+            controller: controller,
+            behavior: headerBehavior,
+            headerColor: theme.backgroundColor,
+            children: <Widget>[
+              if (appBar != null)
+                YgLayoutHeaderChildWidget(
+                  slot: YgLayoutHeaderSlot.appBar,
+                  child: appBar,
+                ),
+              if (bottom != null)
+                YgLayoutHeaderChildWidget(
+                  slot: YgLayoutHeaderSlot.trailing,
+                  child: bottom,
+                ),
+              YgLayoutHeaderLoadingBar(
+                controller: controller,
+              ),
+              YgLayoutHeaderShadow(
+                controller: controller,
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+
+    if (bottomNavigationBar != null) {
+      return Material(
+        color: theme.backgroundColor,
+        child: Column(
+          mainAxisSize: MainAxisSize.max,
+          children: <Widget>[
+            Expanded(
+              // Strip the bottom inset from the content's MediaQuery so
+              // YgLayoutBody doesn't pad bottom safe area on top of the
+              // navigation bar. The bar itself sees the original MediaQuery
+              // (sibling in the Column) and applies its own SafeArea.
+              child: MediaQuery.removePadding(
+                context: context,
+                removeBottom: true,
+                child: contentArea,
+              ),
+            ),
+            bottomNavigationBar,
+          ],
+        ),
+      );
+    }
 
     return Material(
       color: theme.backgroundColor,
-      child: YgLayoutRenderWidget(
-        children: <Widget>[
-          content,
-          MediaQuery.removePadding(
-            removeTop: true,
-            context: context,
-            child: YgLayoutHeaderRenderWidget(
-              padding: MediaQuery.paddingOf(context),
-              controller: controller,
-              behavior: headerBehavior,
-              headerColor: theme.backgroundColor,
-              children: <Widget>[
-                if (appBar != null)
-                  YgLayoutHeaderChildWidget(
-                    slot: YgLayoutHeaderSlot.appBar,
-                    child: appBar,
-                  ),
-                if (bottom != null)
-                  YgLayoutHeaderChildWidget(
-                    slot: YgLayoutHeaderSlot.trailing,
-                    child: bottom,
-                  ),
-                YgLayoutHeaderLoadingBar(
-                  controller: controller,
-                ),
-                YgLayoutHeaderShadow(
-                  controller: controller,
-                ),
-              ],
-            ),
-          ),
-        ],
-      ),
+      child: contentArea,
     );
   }
 }

--- a/yggdrasil/lib/src/components/yg_layout/layout/yg_layout.dart
+++ b/yggdrasil/lib/src/components/yg_layout/layout/yg_layout.dart
@@ -25,6 +25,7 @@ abstract class YgLayout extends StatefulWidget with StatefulWidgetDebugMixin {
     YgHeaderBehavior headerBehavior,
     Widget? appBar,
     Widget? bottom,
+    Widget? bottomNavigationBar,
   }) = _YgLayoutRegular;
 
   /// Creates a layout with tabs.
@@ -41,6 +42,7 @@ abstract class YgLayout extends StatefulWidget with StatefulWidgetDebugMixin {
     bool swiping,
     Widget? bottom,
     Widget? appBar,
+    Widget? bottomNavigationBar,
     ValueChanged<int>? onTabChanged,
     ValueChanged<int>? onTabVisible,
   }) = _YgLayoutTabbed;
@@ -49,6 +51,7 @@ abstract class YgLayout extends StatefulWidget with StatefulWidgetDebugMixin {
     super.key,
     this.appBar,
     this.bottom,
+    this.bottomNavigationBar,
     this.headerBehavior = YgHeaderBehavior.fixed,
   });
 
@@ -63,6 +66,15 @@ abstract class YgLayout extends StatefulWidget with StatefulWidgetDebugMixin {
   /// This widget will get hidden when the user scrolls if [headerBehavior] is
   /// set to hideEverything.
   final Widget? bottom;
+
+  /// A widget pinned to the bottom of the screen, intended for navigation
+  /// bars such as [YgBottomNavigationBar].
+  ///
+  /// The layout reserves vertical space for this widget and strips the bottom
+  /// inset from the [content]'s [MediaQuery] so that the navigation bar is the
+  /// sole owner of the bottom safe area. The content scrolls above the bar
+  /// rather than behind it.
+  final Widget? bottomNavigationBar;
 
   /// The scrolling related header behavior.
   ///

--- a/yggdrasil/lib/src/components/yg_layout/layout/yg_layout_regular.dart
+++ b/yggdrasil/lib/src/components/yg_layout/layout/yg_layout_regular.dart
@@ -7,6 +7,7 @@ class _YgLayoutRegular extends YgLayout {
     required this.child,
     super.appBar,
     super.bottom,
+    super.bottomNavigationBar,
     super.headerBehavior,
   }) : super._();
 
@@ -25,6 +26,7 @@ class _YgLayoutRegularState extends _YgLayoutState<_YgLayoutRegular> {
       headerBehavior: widget.headerBehavior,
       appBar: widget.appBar,
       bottom: widget.bottom,
+      bottomNavigationBar: widget.bottomNavigationBar,
       content: YgLayoutHeaderControllerProvider(
         controller: _controller,
         index: 0,

--- a/yggdrasil/lib/src/components/yg_layout/layout/yg_layout_tabbed.dart
+++ b/yggdrasil/lib/src/components/yg_layout/layout/yg_layout_tabbed.dart
@@ -14,6 +14,7 @@ class _YgLayoutTabbed extends YgLayout {
     super.key,
     super.appBar,
     super.bottom,
+    super.bottomNavigationBar,
     this.onTabChanged,
     this.onTabVisible,
     required this.tabs,
@@ -85,6 +86,7 @@ class _YgLayoutTabbedState extends _YgLayoutState<_YgLayoutTabbed> {
         controller: _controller,
         headerBehavior: widget.headerBehavior,
         appBar: widget.appBar,
+        bottomNavigationBar: widget.bottomNavigationBar,
         bottom: Material(
           type: MaterialType.transparency,
           child: Column(

--- a/yggdrasil/lib/src/theme/_theme.dart
+++ b/yggdrasil/lib/src/theme/_theme.dart
@@ -1,6 +1,7 @@
 export 'app_bar/_app_bar.dart';
 export 'avatar/_avatar.dart';
 export 'badge/_badge.dart';
+export 'bottom_navigation_bar/_bottom_navigation_bar.dart';
 export 'bottom_sheet/_bottom_sheet.dart';
 export 'button/_button.dart';
 export 'button_group/_button_group.dart';

--- a/yggdrasil/lib/src/theme/bottom_navigation_bar/_bottom_navigation_bar.dart
+++ b/yggdrasil/lib/src/theme/bottom_navigation_bar/_bottom_navigation_bar.dart
@@ -1,0 +1,1 @@
+export 'bottom_navigation_bar_theme.dart';

--- a/yggdrasil/lib/src/theme/bottom_navigation_bar/bottom_navigation_bar_theme.dart
+++ b/yggdrasil/lib/src/theme/bottom_navigation_bar/bottom_navigation_bar_theme.dart
@@ -1,0 +1,238 @@
+import 'package:flutter/material.dart';
+import 'package:theme_tailor_annotation/theme_tailor_annotation.dart';
+import 'package:yggdrasil/src/tokens/consumer_dark/_consumer_dark.dart' as consumer_dark;
+import 'package:yggdrasil/src/tokens/consumer_light/_consumer_light.dart' as consumer_light;
+import 'package:yggdrasil/src/tokens/professional_dark/_professional_dark.dart' as professional_dark;
+import 'package:yggdrasil/src/tokens/professional_light/_professional_light.dart' as professional_light;
+
+part 'bottom_navigation_bar_theme.tailor.dart';
+
+@tailorComponent
+class _$YgBottomNavigationBarTheme {
+  // region Background
+
+  static const List<Color> backgroundColor = <Color>[
+    consumer_light.FhColors.backgroundDefault,
+    consumer_dark.FhColors.backgroundDefault,
+    professional_light.FhColors.backgroundDefault,
+    professional_dark.FhColors.backgroundDefault,
+  ];
+
+  static const List<Color> hoverBackgroundColor = <Color>[
+    consumer_light.FhColors.backgroundWeak,
+    consumer_dark.FhColors.backgroundWeak,
+    professional_light.FhColors.backgroundWeak,
+    professional_dark.FhColors.backgroundWeak,
+  ];
+
+  static const List<Color> pressedBackgroundColor = <Color>[
+    consumer_light.FhColors.backgroundWeak,
+    consumer_dark.FhColors.backgroundWeak,
+    professional_light.FhColors.backgroundWeak,
+    professional_dark.FhColors.backgroundWeak,
+  ];
+
+  // endregion
+
+  // region Divider
+
+  static const List<Color> dividerColor = <Color>[
+    consumer_light.FhColors.borderDefault,
+    consumer_dark.FhColors.borderDefault,
+    professional_light.FhColors.borderDefault,
+    professional_dark.FhColors.borderDefault,
+  ];
+
+  static const List<double> dividerHeight = <double>[
+    1.0,
+    1.0,
+    1.0,
+    1.0,
+  ];
+
+  // endregion
+
+  // region Spacing and padding
+
+  /// Padding around an individual item.
+  static const List<EdgeInsets> itemPadding = <EdgeInsets>[
+    EdgeInsets.symmetric(
+      horizontal: consumer_light.FhDimensions.xxs,
+      vertical: consumer_light.FhDimensions.xs,
+    ),
+    EdgeInsets.symmetric(
+      horizontal: consumer_dark.FhDimensions.xxs,
+      vertical: consumer_dark.FhDimensions.xs,
+    ),
+    EdgeInsets.symmetric(
+      horizontal: professional_light.FhDimensions.xxs,
+      vertical: professional_light.FhDimensions.xs,
+    ),
+    EdgeInsets.symmetric(
+      horizontal: professional_dark.FhDimensions.xxs,
+      vertical: professional_dark.FhDimensions.xs,
+    ),
+  ];
+
+  /// Spacing between the icon and the title.
+  static const List<double> iconLabelSpacing = <double>[
+    consumer_light.FhDimensions.xxs,
+    consumer_dark.FhDimensions.xxs,
+    professional_light.FhDimensions.xxs,
+    professional_dark.FhDimensions.xxs,
+  ];
+
+  /// Spacing between the title and the optional subtitle.
+  static const List<double> titleSubtitleSpacing = <double>[
+    2.0,
+    2.0,
+    2.0,
+    2.0,
+  ];
+
+  // endregion
+
+  // region Indicator
+
+  /// Color of the moving selection indicator placed at the top of the bar.
+  ///
+  /// Matches [YgWizardHeader]'s progress foreground so the two components share
+  /// a common selection accent.
+  static const List<Color> indicatorColor = <Color>[
+    consumer_light.FhColors.interactiveHighlightDefault,
+    consumer_dark.FhColors.interactiveHighlightDefault,
+    professional_light.FhColors.interactiveHighlightDefault,
+    professional_dark.FhColors.interactiveHighlightDefault,
+  ];
+
+  /// Stroke height of the indicator. Matches [YgWizardHeader]'s `barStroke`.
+  static const List<double> indicatorHeight = <double>[
+    4.0,
+    4.0,
+    4.0,
+    4.0,
+  ];
+
+  /// Radius applied to the bottom corners of the indicator only — produces a
+  /// rectangle that hangs from the top edge with subtly rounded bottom corners.
+  static const List<BorderRadius> indicatorRadius = <BorderRadius>[
+    BorderRadius.only(
+      bottomLeft: Radius.circular(consumer_light.FhDimensions.xs),
+      bottomRight: Radius.circular(consumer_light.FhDimensions.xs),
+    ),
+    BorderRadius.only(
+      bottomLeft: Radius.circular(consumer_dark.FhDimensions.xs),
+      bottomRight: Radius.circular(consumer_dark.FhDimensions.xs),
+    ),
+    BorderRadius.only(
+      bottomLeft: Radius.circular(professional_light.FhDimensions.xs),
+      bottomRight: Radius.circular(professional_light.FhDimensions.xs),
+    ),
+    BorderRadius.only(
+      bottomLeft: Radius.circular(professional_dark.FhDimensions.xs),
+      bottomRight: Radius.circular(professional_dark.FhDimensions.xs),
+    ),
+  ];
+
+  // endregion
+
+  // region Icons
+
+  static const List<Color> selectedIconColor = <Color>[
+    consumer_light.FhColors.textDefault,
+    consumer_dark.FhColors.textDefault,
+    professional_light.FhColors.textDefault,
+    professional_dark.FhColors.textDefault,
+  ];
+
+  static const List<Color> unselectedIconColor = <Color>[
+    consumer_light.FhColors.iconWeak,
+    consumer_dark.FhColors.iconWeak,
+    professional_light.FhColors.iconWeak,
+    professional_dark.FhColors.iconWeak,
+  ];
+
+  // endregion
+
+  // region Text styles
+
+  static final List<TextStyle> selectedTitleTextStyle = <TextStyle>[
+    consumer_light.FhTextStyles.caption1Bold.copyWith(
+      color: consumer_light.FhColors.textDefault,
+    ),
+    consumer_dark.FhTextStyles.caption1Bold.copyWith(
+      color: consumer_dark.FhColors.textDefault,
+    ),
+    professional_light.FhTextStyles.caption1Bold.copyWith(
+      color: professional_light.FhColors.textDefault,
+    ),
+    professional_dark.FhTextStyles.caption1Bold.copyWith(
+      color: professional_dark.FhColors.textDefault,
+    ),
+  ];
+
+  static final List<TextStyle> unselectedTitleTextStyle = <TextStyle>[
+    consumer_light.FhTextStyles.caption1Regular.copyWith(
+      color: consumer_light.FhColors.textWeak,
+    ),
+    consumer_dark.FhTextStyles.caption1Regular.copyWith(
+      color: consumer_dark.FhColors.textWeak,
+    ),
+    professional_light.FhTextStyles.caption1Regular.copyWith(
+      color: professional_light.FhColors.textWeak,
+    ),
+    professional_dark.FhTextStyles.caption1Regular.copyWith(
+      color: professional_dark.FhColors.textWeak,
+    ),
+  ];
+
+  static final List<TextStyle> selectedSubtitleTextStyle = <TextStyle>[
+    consumer_light.FhTextStyles.caption1Medium.copyWith(
+      color: consumer_light.FhColors.textDefault,
+    ),
+    consumer_dark.FhTextStyles.caption1Medium.copyWith(
+      color: consumer_dark.FhColors.textDefault,
+    ),
+    professional_light.FhTextStyles.caption1Medium.copyWith(
+      color: professional_light.FhColors.textDefault,
+    ),
+    professional_dark.FhTextStyles.caption1Medium.copyWith(
+      color: professional_dark.FhColors.textDefault,
+    ),
+  ];
+
+  static final List<TextStyle> unselectedSubtitleTextStyle = <TextStyle>[
+    consumer_light.FhTextStyles.caption1Regular.copyWith(
+      color: consumer_light.FhColors.textWeak,
+    ),
+    consumer_dark.FhTextStyles.caption1Regular.copyWith(
+      color: consumer_dark.FhColors.textWeak,
+    ),
+    professional_light.FhTextStyles.caption1Regular.copyWith(
+      color: professional_light.FhColors.textWeak,
+    ),
+    professional_dark.FhTextStyles.caption1Regular.copyWith(
+      color: professional_dark.FhColors.textWeak,
+    ),
+  ];
+
+  // endregion
+
+  // region Animation
+
+  static const List<Duration> animationDuration = <Duration>[
+    Duration(milliseconds: 250),
+    Duration(milliseconds: 250),
+    Duration(milliseconds: 250),
+    Duration(milliseconds: 250),
+  ];
+
+  static const List<Curve> animationCurve = <Curve>[
+    Curves.easeOut,
+    Curves.easeOut,
+    Curves.easeOut,
+    Curves.easeOut,
+  ];
+
+  // endregion
+}

--- a/yggdrasil/lib/src/theme/bottom_navigation_bar/bottom_navigation_bar_theme.tailor.dart
+++ b/yggdrasil/lib/src/theme/bottom_navigation_bar/bottom_navigation_bar_theme.tailor.dart
@@ -1,0 +1,282 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint, unused_element, unnecessary_cast
+
+part of 'bottom_navigation_bar_theme.dart';
+
+// **************************************************************************
+// TailorAnnotationsGenerator
+// **************************************************************************
+
+class YgBottomNavigationBarTheme extends ThemeExtension<YgBottomNavigationBarTheme> {
+  const YgBottomNavigationBarTheme({
+    required this.animationCurve,
+    required this.animationDuration,
+    required this.backgroundColor,
+    required this.dividerColor,
+    required this.dividerHeight,
+    required this.hoverBackgroundColor,
+    required this.iconLabelSpacing,
+    required this.indicatorColor,
+    required this.indicatorHeight,
+    required this.indicatorRadius,
+    required this.itemPadding,
+    required this.pressedBackgroundColor,
+    required this.selectedIconColor,
+    required this.selectedSubtitleTextStyle,
+    required this.selectedTitleTextStyle,
+    required this.titleSubtitleSpacing,
+    required this.unselectedIconColor,
+    required this.unselectedSubtitleTextStyle,
+    required this.unselectedTitleTextStyle,
+  });
+
+  final Curve animationCurve;
+  final Duration animationDuration;
+  final Color backgroundColor;
+  final Color dividerColor;
+  final double dividerHeight;
+  final Color hoverBackgroundColor;
+
+  /// Spacing between the icon and the title.
+  final double iconLabelSpacing;
+
+  /// Color of the moving selection indicator placed at the top of the bar.
+  ///
+  /// Matches [YgWizardHeader]'s progress foreground so the two components share
+  /// a common selection accent.
+  final Color indicatorColor;
+  final double indicatorHeight;
+  final BorderRadius indicatorRadius;
+
+  /// Padding around an individual item.
+  final EdgeInsets itemPadding;
+  final Color pressedBackgroundColor;
+  final Color selectedIconColor;
+  final TextStyle selectedSubtitleTextStyle;
+  final TextStyle selectedTitleTextStyle;
+
+  /// Spacing between the title and the optional subtitle.
+  final double titleSubtitleSpacing;
+  final Color unselectedIconColor;
+  final TextStyle unselectedSubtitleTextStyle;
+  final TextStyle unselectedTitleTextStyle;
+
+  static final YgBottomNavigationBarTheme consumerLight = YgBottomNavigationBarTheme(
+    animationCurve: _$YgBottomNavigationBarTheme.animationCurve[0],
+    animationDuration: _$YgBottomNavigationBarTheme.animationDuration[0],
+    backgroundColor: _$YgBottomNavigationBarTheme.backgroundColor[0],
+    dividerColor: _$YgBottomNavigationBarTheme.dividerColor[0],
+    dividerHeight: _$YgBottomNavigationBarTheme.dividerHeight[0],
+    hoverBackgroundColor: _$YgBottomNavigationBarTheme.hoverBackgroundColor[0],
+    iconLabelSpacing: _$YgBottomNavigationBarTheme.iconLabelSpacing[0],
+    indicatorColor: _$YgBottomNavigationBarTheme.indicatorColor[0],
+    indicatorHeight: _$YgBottomNavigationBarTheme.indicatorHeight[0],
+    indicatorRadius: _$YgBottomNavigationBarTheme.indicatorRadius[0],
+    itemPadding: _$YgBottomNavigationBarTheme.itemPadding[0],
+    pressedBackgroundColor: _$YgBottomNavigationBarTheme.pressedBackgroundColor[0],
+    selectedIconColor: _$YgBottomNavigationBarTheme.selectedIconColor[0],
+    selectedSubtitleTextStyle: _$YgBottomNavigationBarTheme.selectedSubtitleTextStyle[0],
+    selectedTitleTextStyle: _$YgBottomNavigationBarTheme.selectedTitleTextStyle[0],
+    titleSubtitleSpacing: _$YgBottomNavigationBarTheme.titleSubtitleSpacing[0],
+    unselectedIconColor: _$YgBottomNavigationBarTheme.unselectedIconColor[0],
+    unselectedSubtitleTextStyle: _$YgBottomNavigationBarTheme.unselectedSubtitleTextStyle[0],
+    unselectedTitleTextStyle: _$YgBottomNavigationBarTheme.unselectedTitleTextStyle[0],
+  );
+
+  static final YgBottomNavigationBarTheme consumerDark = YgBottomNavigationBarTheme(
+    animationCurve: _$YgBottomNavigationBarTheme.animationCurve[1],
+    animationDuration: _$YgBottomNavigationBarTheme.animationDuration[1],
+    backgroundColor: _$YgBottomNavigationBarTheme.backgroundColor[1],
+    dividerColor: _$YgBottomNavigationBarTheme.dividerColor[1],
+    dividerHeight: _$YgBottomNavigationBarTheme.dividerHeight[1],
+    hoverBackgroundColor: _$YgBottomNavigationBarTheme.hoverBackgroundColor[1],
+    iconLabelSpacing: _$YgBottomNavigationBarTheme.iconLabelSpacing[1],
+    indicatorColor: _$YgBottomNavigationBarTheme.indicatorColor[1],
+    indicatorHeight: _$YgBottomNavigationBarTheme.indicatorHeight[1],
+    indicatorRadius: _$YgBottomNavigationBarTheme.indicatorRadius[1],
+    itemPadding: _$YgBottomNavigationBarTheme.itemPadding[1],
+    pressedBackgroundColor: _$YgBottomNavigationBarTheme.pressedBackgroundColor[1],
+    selectedIconColor: _$YgBottomNavigationBarTheme.selectedIconColor[1],
+    selectedSubtitleTextStyle: _$YgBottomNavigationBarTheme.selectedSubtitleTextStyle[1],
+    selectedTitleTextStyle: _$YgBottomNavigationBarTheme.selectedTitleTextStyle[1],
+    titleSubtitleSpacing: _$YgBottomNavigationBarTheme.titleSubtitleSpacing[1],
+    unselectedIconColor: _$YgBottomNavigationBarTheme.unselectedIconColor[1],
+    unselectedSubtitleTextStyle: _$YgBottomNavigationBarTheme.unselectedSubtitleTextStyle[1],
+    unselectedTitleTextStyle: _$YgBottomNavigationBarTheme.unselectedTitleTextStyle[1],
+  );
+
+  static final YgBottomNavigationBarTheme professionalLight = YgBottomNavigationBarTheme(
+    animationCurve: _$YgBottomNavigationBarTheme.animationCurve[2],
+    animationDuration: _$YgBottomNavigationBarTheme.animationDuration[2],
+    backgroundColor: _$YgBottomNavigationBarTheme.backgroundColor[2],
+    dividerColor: _$YgBottomNavigationBarTheme.dividerColor[2],
+    dividerHeight: _$YgBottomNavigationBarTheme.dividerHeight[2],
+    hoverBackgroundColor: _$YgBottomNavigationBarTheme.hoverBackgroundColor[2],
+    iconLabelSpacing: _$YgBottomNavigationBarTheme.iconLabelSpacing[2],
+    indicatorColor: _$YgBottomNavigationBarTheme.indicatorColor[2],
+    indicatorHeight: _$YgBottomNavigationBarTheme.indicatorHeight[2],
+    indicatorRadius: _$YgBottomNavigationBarTheme.indicatorRadius[2],
+    itemPadding: _$YgBottomNavigationBarTheme.itemPadding[2],
+    pressedBackgroundColor: _$YgBottomNavigationBarTheme.pressedBackgroundColor[2],
+    selectedIconColor: _$YgBottomNavigationBarTheme.selectedIconColor[2],
+    selectedSubtitleTextStyle: _$YgBottomNavigationBarTheme.selectedSubtitleTextStyle[2],
+    selectedTitleTextStyle: _$YgBottomNavigationBarTheme.selectedTitleTextStyle[2],
+    titleSubtitleSpacing: _$YgBottomNavigationBarTheme.titleSubtitleSpacing[2],
+    unselectedIconColor: _$YgBottomNavigationBarTheme.unselectedIconColor[2],
+    unselectedSubtitleTextStyle: _$YgBottomNavigationBarTheme.unselectedSubtitleTextStyle[2],
+    unselectedTitleTextStyle: _$YgBottomNavigationBarTheme.unselectedTitleTextStyle[2],
+  );
+
+  static final YgBottomNavigationBarTheme professionalDark = YgBottomNavigationBarTheme(
+    animationCurve: _$YgBottomNavigationBarTheme.animationCurve[3],
+    animationDuration: _$YgBottomNavigationBarTheme.animationDuration[3],
+    backgroundColor: _$YgBottomNavigationBarTheme.backgroundColor[3],
+    dividerColor: _$YgBottomNavigationBarTheme.dividerColor[3],
+    dividerHeight: _$YgBottomNavigationBarTheme.dividerHeight[3],
+    hoverBackgroundColor: _$YgBottomNavigationBarTheme.hoverBackgroundColor[3],
+    iconLabelSpacing: _$YgBottomNavigationBarTheme.iconLabelSpacing[3],
+    indicatorColor: _$YgBottomNavigationBarTheme.indicatorColor[3],
+    indicatorHeight: _$YgBottomNavigationBarTheme.indicatorHeight[3],
+    indicatorRadius: _$YgBottomNavigationBarTheme.indicatorRadius[3],
+    itemPadding: _$YgBottomNavigationBarTheme.itemPadding[3],
+    pressedBackgroundColor: _$YgBottomNavigationBarTheme.pressedBackgroundColor[3],
+    selectedIconColor: _$YgBottomNavigationBarTheme.selectedIconColor[3],
+    selectedSubtitleTextStyle: _$YgBottomNavigationBarTheme.selectedSubtitleTextStyle[3],
+    selectedTitleTextStyle: _$YgBottomNavigationBarTheme.selectedTitleTextStyle[3],
+    titleSubtitleSpacing: _$YgBottomNavigationBarTheme.titleSubtitleSpacing[3],
+    unselectedIconColor: _$YgBottomNavigationBarTheme.unselectedIconColor[3],
+    unselectedSubtitleTextStyle: _$YgBottomNavigationBarTheme.unselectedSubtitleTextStyle[3],
+    unselectedTitleTextStyle: _$YgBottomNavigationBarTheme.unselectedTitleTextStyle[3],
+  );
+
+  static final themes = [
+    consumerLight,
+    consumerDark,
+    professionalLight,
+    professionalDark,
+  ];
+
+  @override
+  YgBottomNavigationBarTheme copyWith({
+    Curve? animationCurve,
+    Duration? animationDuration,
+    Color? backgroundColor,
+    Color? dividerColor,
+    double? dividerHeight,
+    Color? hoverBackgroundColor,
+    double? iconLabelSpacing,
+    Color? indicatorColor,
+    double? indicatorHeight,
+    BorderRadius? indicatorRadius,
+    EdgeInsets? itemPadding,
+    Color? pressedBackgroundColor,
+    Color? selectedIconColor,
+    TextStyle? selectedSubtitleTextStyle,
+    TextStyle? selectedTitleTextStyle,
+    double? titleSubtitleSpacing,
+    Color? unselectedIconColor,
+    TextStyle? unselectedSubtitleTextStyle,
+    TextStyle? unselectedTitleTextStyle,
+  }) {
+    return YgBottomNavigationBarTheme(
+      animationCurve: animationCurve ?? this.animationCurve,
+      animationDuration: animationDuration ?? this.animationDuration,
+      backgroundColor: backgroundColor ?? this.backgroundColor,
+      dividerColor: dividerColor ?? this.dividerColor,
+      dividerHeight: dividerHeight ?? this.dividerHeight,
+      hoverBackgroundColor: hoverBackgroundColor ?? this.hoverBackgroundColor,
+      iconLabelSpacing: iconLabelSpacing ?? this.iconLabelSpacing,
+      indicatorColor: indicatorColor ?? this.indicatorColor,
+      indicatorHeight: indicatorHeight ?? this.indicatorHeight,
+      indicatorRadius: indicatorRadius ?? this.indicatorRadius,
+      itemPadding: itemPadding ?? this.itemPadding,
+      pressedBackgroundColor: pressedBackgroundColor ?? this.pressedBackgroundColor,
+      selectedIconColor: selectedIconColor ?? this.selectedIconColor,
+      selectedSubtitleTextStyle: selectedSubtitleTextStyle ?? this.selectedSubtitleTextStyle,
+      selectedTitleTextStyle: selectedTitleTextStyle ?? this.selectedTitleTextStyle,
+      titleSubtitleSpacing: titleSubtitleSpacing ?? this.titleSubtitleSpacing,
+      unselectedIconColor: unselectedIconColor ?? this.unselectedIconColor,
+      unselectedSubtitleTextStyle: unselectedSubtitleTextStyle ?? this.unselectedSubtitleTextStyle,
+      unselectedTitleTextStyle: unselectedTitleTextStyle ?? this.unselectedTitleTextStyle,
+    );
+  }
+
+  @override
+  YgBottomNavigationBarTheme lerp(covariant ThemeExtension<YgBottomNavigationBarTheme>? other, double t) {
+    if (other is! YgBottomNavigationBarTheme) return this as YgBottomNavigationBarTheme;
+    return YgBottomNavigationBarTheme(
+      animationCurve: t < 0.5 ? animationCurve : other.animationCurve,
+      animationDuration: t < 0.5 ? animationDuration : other.animationDuration,
+      backgroundColor: Color.lerp(backgroundColor, other.backgroundColor, t)!,
+      dividerColor: Color.lerp(dividerColor, other.dividerColor, t)!,
+      dividerHeight: t < 0.5 ? dividerHeight : other.dividerHeight,
+      hoverBackgroundColor: Color.lerp(hoverBackgroundColor, other.hoverBackgroundColor, t)!,
+      iconLabelSpacing: t < 0.5 ? iconLabelSpacing : other.iconLabelSpacing,
+      indicatorColor: Color.lerp(indicatorColor, other.indicatorColor, t)!,
+      indicatorHeight: t < 0.5 ? indicatorHeight : other.indicatorHeight,
+      indicatorRadius: t < 0.5 ? indicatorRadius : other.indicatorRadius,
+      itemPadding: t < 0.5 ? itemPadding : other.itemPadding,
+      pressedBackgroundColor: Color.lerp(pressedBackgroundColor, other.pressedBackgroundColor, t)!,
+      selectedIconColor: Color.lerp(selectedIconColor, other.selectedIconColor, t)!,
+      selectedSubtitleTextStyle: TextStyle.lerp(selectedSubtitleTextStyle, other.selectedSubtitleTextStyle, t)!,
+      selectedTitleTextStyle: TextStyle.lerp(selectedTitleTextStyle, other.selectedTitleTextStyle, t)!,
+      titleSubtitleSpacing: t < 0.5 ? titleSubtitleSpacing : other.titleSubtitleSpacing,
+      unselectedIconColor: Color.lerp(unselectedIconColor, other.unselectedIconColor, t)!,
+      unselectedSubtitleTextStyle: TextStyle.lerp(unselectedSubtitleTextStyle, other.unselectedSubtitleTextStyle, t)!,
+      unselectedTitleTextStyle: TextStyle.lerp(unselectedTitleTextStyle, other.unselectedTitleTextStyle, t)!,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is YgBottomNavigationBarTheme &&
+            const DeepCollectionEquality().equals(animationCurve, other.animationCurve) &&
+            const DeepCollectionEquality().equals(animationDuration, other.animationDuration) &&
+            const DeepCollectionEquality().equals(backgroundColor, other.backgroundColor) &&
+            const DeepCollectionEquality().equals(dividerColor, other.dividerColor) &&
+            const DeepCollectionEquality().equals(dividerHeight, other.dividerHeight) &&
+            const DeepCollectionEquality().equals(hoverBackgroundColor, other.hoverBackgroundColor) &&
+            const DeepCollectionEquality().equals(iconLabelSpacing, other.iconLabelSpacing) &&
+            const DeepCollectionEquality().equals(indicatorColor, other.indicatorColor) &&
+            const DeepCollectionEquality().equals(indicatorHeight, other.indicatorHeight) &&
+            const DeepCollectionEquality().equals(indicatorRadius, other.indicatorRadius) &&
+            const DeepCollectionEquality().equals(itemPadding, other.itemPadding) &&
+            const DeepCollectionEquality().equals(pressedBackgroundColor, other.pressedBackgroundColor) &&
+            const DeepCollectionEquality().equals(selectedIconColor, other.selectedIconColor) &&
+            const DeepCollectionEquality().equals(selectedSubtitleTextStyle, other.selectedSubtitleTextStyle) &&
+            const DeepCollectionEquality().equals(selectedTitleTextStyle, other.selectedTitleTextStyle) &&
+            const DeepCollectionEquality().equals(titleSubtitleSpacing, other.titleSubtitleSpacing) &&
+            const DeepCollectionEquality().equals(unselectedIconColor, other.unselectedIconColor) &&
+            const DeepCollectionEquality().equals(unselectedSubtitleTextStyle, other.unselectedSubtitleTextStyle) &&
+            const DeepCollectionEquality().equals(unselectedTitleTextStyle, other.unselectedTitleTextStyle));
+  }
+
+  @override
+  int get hashCode {
+    return Object.hash(
+      runtimeType.hashCode,
+      const DeepCollectionEquality().hash(animationCurve),
+      const DeepCollectionEquality().hash(animationDuration),
+      const DeepCollectionEquality().hash(backgroundColor),
+      const DeepCollectionEquality().hash(dividerColor),
+      const DeepCollectionEquality().hash(dividerHeight),
+      const DeepCollectionEquality().hash(hoverBackgroundColor),
+      const DeepCollectionEquality().hash(iconLabelSpacing),
+      const DeepCollectionEquality().hash(indicatorColor),
+      const DeepCollectionEquality().hash(indicatorHeight),
+      const DeepCollectionEquality().hash(indicatorRadius),
+      const DeepCollectionEquality().hash(itemPadding),
+      const DeepCollectionEquality().hash(pressedBackgroundColor),
+      const DeepCollectionEquality().hash(selectedIconColor),
+      const DeepCollectionEquality().hash(selectedSubtitleTextStyle),
+      const DeepCollectionEquality().hash(selectedTitleTextStyle),
+      const DeepCollectionEquality().hash(titleSubtitleSpacing),
+      const DeepCollectionEquality().hash(unselectedIconColor),
+      const DeepCollectionEquality().hash(unselectedSubtitleTextStyle),
+      const DeepCollectionEquality().hash(unselectedTitleTextStyle),
+    );
+  }
+}

--- a/yggdrasil/lib/src/theme/theme.dart
+++ b/yggdrasil/lib/src/theme/theme.dart
@@ -34,6 +34,9 @@ class _$YgTheme {
   static final List<YgBadgeTheme> badgeTheme = YgBadgeTheme.themes;
 
   @themeExtension
+  static final List<YgBottomNavigationBarTheme> bottomNavigationBarTheme = YgBottomNavigationBarTheme.themes;
+
+  @themeExtension
   static final List<YgBottomSheetTheme> bottomSheetTheme = YgBottomSheetTheme.themes;
 
   @themeExtension

--- a/yggdrasil/lib/src/theme/theme.tailor.dart
+++ b/yggdrasil/lib/src/theme/theme.tailor.dart
@@ -13,6 +13,7 @@ class YgTheme extends ThemeExtension<YgTheme> {
     required this.appBarTheme,
     required this.avatarTheme,
     required this.badgeTheme,
+    required this.bottomNavigationBarTheme,
     required this.bottomSheetTheme,
     required this.buttonGroupTheme,
     required this.buttonTheme,
@@ -56,6 +57,7 @@ class YgTheme extends ThemeExtension<YgTheme> {
   final YgAppBarTheme appBarTheme;
   final YgAvatarTheme avatarTheme;
   final YgBadgeTheme badgeTheme;
+  final YgBottomNavigationBarTheme bottomNavigationBarTheme;
   final YgBottomSheetTheme bottomSheetTheme;
   final YgButtonGroupTheme buttonGroupTheme;
   final YgButtonTheme buttonTheme;
@@ -99,6 +101,7 @@ class YgTheme extends ThemeExtension<YgTheme> {
     appBarTheme: _$YgTheme.appBarTheme[0],
     avatarTheme: _$YgTheme.avatarTheme[0],
     badgeTheme: _$YgTheme.badgeTheme[0],
+    bottomNavigationBarTheme: _$YgTheme.bottomNavigationBarTheme[0],
     bottomSheetTheme: _$YgTheme.bottomSheetTheme[0],
     buttonGroupTheme: _$YgTheme.buttonGroupTheme[0],
     buttonTheme: _$YgTheme.buttonTheme[0],
@@ -143,6 +146,7 @@ class YgTheme extends ThemeExtension<YgTheme> {
     appBarTheme: _$YgTheme.appBarTheme[1],
     avatarTheme: _$YgTheme.avatarTheme[1],
     badgeTheme: _$YgTheme.badgeTheme[1],
+    bottomNavigationBarTheme: _$YgTheme.bottomNavigationBarTheme[1],
     bottomSheetTheme: _$YgTheme.bottomSheetTheme[1],
     buttonGroupTheme: _$YgTheme.buttonGroupTheme[1],
     buttonTheme: _$YgTheme.buttonTheme[1],
@@ -187,6 +191,7 @@ class YgTheme extends ThemeExtension<YgTheme> {
     appBarTheme: _$YgTheme.appBarTheme[2],
     avatarTheme: _$YgTheme.avatarTheme[2],
     badgeTheme: _$YgTheme.badgeTheme[2],
+    bottomNavigationBarTheme: _$YgTheme.bottomNavigationBarTheme[2],
     bottomSheetTheme: _$YgTheme.bottomSheetTheme[2],
     buttonGroupTheme: _$YgTheme.buttonGroupTheme[2],
     buttonTheme: _$YgTheme.buttonTheme[2],
@@ -231,6 +236,7 @@ class YgTheme extends ThemeExtension<YgTheme> {
     appBarTheme: _$YgTheme.appBarTheme[3],
     avatarTheme: _$YgTheme.avatarTheme[3],
     badgeTheme: _$YgTheme.badgeTheme[3],
+    bottomNavigationBarTheme: _$YgTheme.bottomNavigationBarTheme[3],
     bottomSheetTheme: _$YgTheme.bottomSheetTheme[3],
     buttonGroupTheme: _$YgTheme.buttonGroupTheme[3],
     buttonTheme: _$YgTheme.buttonTheme[3],
@@ -283,6 +289,7 @@ class YgTheme extends ThemeExtension<YgTheme> {
     YgAppBarTheme? appBarTheme,
     YgAvatarTheme? avatarTheme,
     YgBadgeTheme? badgeTheme,
+    YgBottomNavigationBarTheme? bottomNavigationBarTheme,
     YgBottomSheetTheme? bottomSheetTheme,
     YgButtonGroupTheme? buttonGroupTheme,
     YgButtonTheme? buttonTheme,
@@ -326,6 +333,7 @@ class YgTheme extends ThemeExtension<YgTheme> {
       appBarTheme: appBarTheme ?? this.appBarTheme,
       avatarTheme: avatarTheme ?? this.avatarTheme,
       badgeTheme: badgeTheme ?? this.badgeTheme,
+      bottomNavigationBarTheme: bottomNavigationBarTheme ?? this.bottomNavigationBarTheme,
       bottomSheetTheme: bottomSheetTheme ?? this.bottomSheetTheme,
       buttonGroupTheme: buttonGroupTheme ?? this.buttonGroupTheme,
       buttonTheme: buttonTheme ?? this.buttonTheme,
@@ -374,6 +382,8 @@ class YgTheme extends ThemeExtension<YgTheme> {
       appBarTheme: appBarTheme.lerp(other.appBarTheme, t) as YgAppBarTheme,
       avatarTheme: avatarTheme.lerp(other.avatarTheme, t) as YgAvatarTheme,
       badgeTheme: badgeTheme.lerp(other.badgeTheme, t) as YgBadgeTheme,
+      bottomNavigationBarTheme:
+          bottomNavigationBarTheme.lerp(other.bottomNavigationBarTheme, t) as YgBottomNavigationBarTheme,
       bottomSheetTheme: bottomSheetTheme.lerp(other.bottomSheetTheme, t) as YgBottomSheetTheme,
       buttonGroupTheme: buttonGroupTheme.lerp(other.buttonGroupTheme, t) as YgButtonGroupTheme,
       buttonTheme: buttonTheme.lerp(other.buttonTheme, t) as YgButtonTheme,
@@ -424,6 +434,7 @@ class YgTheme extends ThemeExtension<YgTheme> {
             const DeepCollectionEquality().equals(appBarTheme, other.appBarTheme) &&
             const DeepCollectionEquality().equals(avatarTheme, other.avatarTheme) &&
             const DeepCollectionEquality().equals(badgeTheme, other.badgeTheme) &&
+            const DeepCollectionEquality().equals(bottomNavigationBarTheme, other.bottomNavigationBarTheme) &&
             const DeepCollectionEquality().equals(bottomSheetTheme, other.bottomSheetTheme) &&
             const DeepCollectionEquality().equals(buttonGroupTheme, other.buttonGroupTheme) &&
             const DeepCollectionEquality().equals(buttonTheme, other.buttonTheme) &&
@@ -471,6 +482,7 @@ class YgTheme extends ThemeExtension<YgTheme> {
       const DeepCollectionEquality().hash(appBarTheme),
       const DeepCollectionEquality().hash(avatarTheme),
       const DeepCollectionEquality().hash(badgeTheme),
+      const DeepCollectionEquality().hash(bottomNavigationBarTheme),
       const DeepCollectionEquality().hash(bottomSheetTheme),
       const DeepCollectionEquality().hash(buttonGroupTheme),
       const DeepCollectionEquality().hash(buttonTheme),
@@ -518,6 +530,7 @@ extension YgThemeBuildContextProps on BuildContext {
   YgAppBarTheme get appBarTheme => ygTheme.appBarTheme;
   YgAvatarTheme get avatarTheme => ygTheme.avatarTheme;
   YgBadgeTheme get badgeTheme => ygTheme.badgeTheme;
+  YgBottomNavigationBarTheme get bottomNavigationBarTheme => ygTheme.bottomNavigationBarTheme;
   YgBottomSheetTheme get bottomSheetTheme => ygTheme.bottomSheetTheme;
   YgButtonGroupTheme get buttonGroupTheme => ygTheme.buttonGroupTheme;
   YgButtonTheme get buttonTheme => ygTheme.buttonTheme;

--- a/yggdrasil/lib/src/utils/yg_inherited_padding/yg_inherited_render_padding_provider_mixin.dart
+++ b/yggdrasil/lib/src/utils/yg_inherited_padding/yg_inherited_render_padding_provider_mixin.dart
@@ -8,17 +8,4 @@ mixin YgInheritedRenderPaddingProviderMixin on RenderObject {
   void setPadding(EdgeInsets padding) {
     _padding = padding;
   }
-
-  @override
-  void layout(
-    Constraints constraints, {
-    bool parentUsesSize = false,
-  }) {
-    // Prevent using outdated padding.
-    _padding = null;
-    super.layout(
-      constraints,
-      parentUsesSize: parentUsesSize,
-    );
-  }
 }


### PR DESCRIPTION
# Checklist

- [ ] Self review has been performed.
- [ ] PR description contains information about what's new using valid PR tags.
- [ ] Add video with happy path or screenshot.

# Changes

[feature] Added YgBottomNavigationBar component. 
[feature] YgLayout internals updated to lay out and inset around the new bottom slot (yg_layout_internal.dart, yg_layout_header_render_widget.dart).          
[dev-feature] Minor cleanup in yg_inherited_render_padding_provider_mixin.dart.
