### PR TITLE
fixes

### DIFF
--- a/yggdrasil/lib/src/components/yg_layout/body/widgets/yg_layout_body_internal.dart
+++ b/yggdrasil/lib/src/components/yg_layout/body/widgets/yg_layout_body_internal.dart
@@ -56,6 +56,7 @@ class _YgLayoutBodyInternalState extends State<YgLayoutBodyInternal> {
     if (provider != null) {
       provider.controller.unregisterView(
         provider.index,
+        _controller,
       );
     }
 
@@ -72,7 +73,7 @@ class _YgLayoutBodyInternalState extends State<YgLayoutBodyInternal> {
 
     _provider = provider;
 
-    oldProvider?.controller.unregisterView(oldProvider.index);
+    oldProvider?.controller.unregisterView(oldProvider.index, _controller);
     provider?.controller.registerView(provider.index, _controller);
   }
 

--- a/yggdrasil/lib/src/components/yg_layout/layout/controller/yg_layout_header_controller.dart
+++ b/yggdrasil/lib/src/components/yg_layout/layout/controller/yg_layout_header_controller.dart
@@ -107,16 +107,22 @@ class YgLayoutHeaderController extends ValueNotifier<YgLayoutHeaderControllerVal
     }
   }
 
-  void unregisterView(int index) {
-    final YgLayoutBodyController? oldController = _viewControllers.remove(index);
-    if (oldController == null) {
+  void unregisterView(int index, YgLayoutBodyController controller) {
+    // The old body's [State.dispose] runs *after* the new body's
+    // [State.initState] when the body widget is swapped in place, so the slot
+    // may already be owned by a newer controller by the time we get here.
+    // Only clear the slot if the controller being unregistered is still the
+    // one registered for [index].
+    if (_viewControllers[index] != controller) {
+      controller.detach();
       return;
     }
 
-    oldController.detach();
+    _viewControllers.remove(index);
+    controller.detach();
 
     if (index == _activeView) {
-      _updateActiveViewController(oldController, null);
+      _updateActiveViewController(controller, null);
     }
   }
 


### PR DESCRIPTION
# Checklist

- [ ] Self review has been performed.
- [ ] PR description contains information about what's new using valid PR tags.
- [ ] Add video with happy path or screenshot.

# Changes

[fix] Fixed YgLayout appbar shadow not reacting to scrolling after the YgLayoutBody widget is swapped in place (e.g. switching tabs in a single YgLayout that hosts  a YgBottomNavigationBar). The old body's late-running dispose was registering the new body's controller from the shared YgLayoutHeaderController, so the shadow stayed frozen at "hidden" no matter how the user scrolled the new page.


