### PR TITLE
fixes

### DIFF
--- a/demo_app/lib/screens/expanding_list_tile/expanding_list_tile_screen.dart
+++ b/demo_app/lib/screens/expanding_list_tile/expanding_list_tile_screen.dart
@@ -3,7 +3,7 @@ import 'package:yggdrasil/yggdrasil.dart';
 import 'package:yggdrasil_demo/core/_core.dart';
 import 'package:yggdrasil_demo/widgets/_widgets.dart';
 
-class ExpandingListTileScreen extends StatelessWidget {
+class ExpandingListTileScreen extends StatefulWidget {
   const ExpandingListTileScreen({super.key});
 
   static const String routeName = 'ExpandingListTileScreen';
@@ -14,6 +14,13 @@ class ExpandingListTileScreen extends StatelessWidget {
       screen: const ExpandingListTileScreen(),
     );
   }
+
+  @override
+  State<ExpandingListTileScreen> createState() => _ExpandingListTileScreenState();
+}
+
+class _ExpandingListTileScreenState extends State<ExpandingListTileScreen> {
+  double _temperatureValue = 0.5;
 
   @override
   Widget build(BuildContext context) {
@@ -114,6 +121,19 @@ class ExpandingListTileScreen extends StatelessWidget {
                 YgIcon(YgIcons.info, size: YgIconSize.large),
                 YgIcon(YgIcons.info, size: YgIconSize.large),
               ],
+              child: child,
+            ),
+            YgExpandingListTile(
+              title: 'With always visible content',
+              subtitle: 'Temperature slider visible without expanding',
+              alwaysVisibleContent: YgSlider(
+                value: _temperatureValue,
+                variant: YgSliderVariant.temperature,
+                valueIndicator: true,
+                onEditingComplete: (double newValue) => setState(
+                  () => _temperatureValue = newValue,
+                ),
+              ),
               child: child,
             ),
           ],

--- a/yggdrasil/lib/src/components/yg_list_tile/variants/yg_expanding_list_tile.dart
+++ b/yggdrasil/lib/src/components/yg_list_tile/variants/yg_expanding_list_tile.dart
@@ -26,6 +26,7 @@ final class YgExpandingListTile extends StatelessWidget with StatelessWidgetDebu
     this.subtitleIcon,
     this.leadingWidgets,
     this.supportingWidgets,
+    this.alwaysVisibleContent,
     this.onInfoTap,
     this.controller,
     this.onExpandedChanged,
@@ -54,6 +55,15 @@ final class YgExpandingListTile extends StatelessWidget with StatelessWidgetDebu
   ///
   /// Will be stacked on top of each other when there is more than one specified.
   final List<Widget>? supportingWidgets;
+
+  /// Content which is visible even when the list tile is not expanded.
+  ///
+  /// Rendered below the main content of the list tile and above [child] when
+  /// the list tile is expanded.
+  ///
+  /// Taps on this content do not toggle the expansion of the list tile, so it
+  /// can safely contain interactive widgets like a [YgSlider].
+  final Widget? alwaysVisibleContent;
 
   /// When provided, shows an info button next to the title.
   ///
@@ -130,7 +140,7 @@ final class YgExpandingListTile extends StatelessWidget with StatelessWidgetDebu
             ),
             builder: (BuildContext context, Widget body) {
               return YgExpander(
-                headerBuilder: (BuildContext _, YgExpansionController __) => body,
+                headerBuilder: (BuildContext _, YgExpansionController __) => _buildHeader(theme, body),
                 duration: theme.animationDuration,
                 curve: theme.animationCurve,
                 alignment: Alignment.bottomCenter,
@@ -147,6 +157,39 @@ final class YgExpandingListTile extends StatelessWidget with StatelessWidgetDebu
       ),
     );
   }
+
+  /// Builds the always visible part of the list tile.
+  ///
+  /// Consists of the [body] of the list tile and [alwaysVisibleContent] below
+  /// it when provided.
+  Widget _buildHeader(YgListTileTheme theme, Widget body) {
+    final Widget? alwaysVisibleContent = this.alwaysVisibleContent;
+
+    if (alwaysVisibleContent == null) {
+      return body;
+    }
+
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: <Widget>[
+        body,
+        // Absorbs taps on the always visible content so interacting with it
+        // does not toggle the expansion of the list tile.
+        GestureDetector(
+          onTap: _absorbTap,
+          behavior: HitTestBehavior.opaque,
+          excludeFromSemantics: true,
+          child: alwaysVisibleContent,
+        ),
+      ].withVerticalSpacing(theme.contentSpacing),
+    );
+  }
+
+  /// Intentionally does nothing.
+  ///
+  /// Claims taps on [alwaysVisibleContent] in the gesture arena so they do not
+  /// reach the tap handler toggling the expansion of the list tile.
+  static void _absorbTap() {}
 
   @override
   YgDebugType get debugType => YgDebugType.intractable;

--- a/yggdrasil/test/yg_expanding_list_tile_golden_test.dart
+++ b/yggdrasil/test/yg_expanding_list_tile_golden_test.dart
@@ -16,6 +16,12 @@ void main() {
         color: Colors.green,
       );
 
+      final Container alwaysVisibleContent = Container(
+        width: 100,
+        height: 50,
+        color: Colors.blue,
+      );
+
       final GoldenTestGroup ygExpandingListTileGoldenTestGroup = GoldenTestGroup(
         columns: 2,
         scenarioConstraints: YgGoldenTestValues.scenarioConstraints,
@@ -225,6 +231,32 @@ void main() {
               supportingWidgets: const <Widget>[
                 YgIcon(YgIcons.info),
               ],
+              child: child,
+            ),
+          ),
+          GoldenTestScenario(
+            name: 'With always visible content',
+            child: YgExpandingListTile(
+              title: YgGoldenTestValues.shortText,
+              alwaysVisibleContent: alwaysVisibleContent,
+              child: child,
+            ),
+          ),
+          GoldenTestScenario(
+            name: 'With always visible content, title and subtitle',
+            child: YgExpandingListTile(
+              title: YgGoldenTestValues.shortText,
+              subtitle: YgGoldenTestValues.mediumText,
+              alwaysVisibleContent: alwaysVisibleContent,
+              child: child,
+            ),
+          ),
+          GoldenTestScenario(
+            name: 'Expanded, with always visible content',
+            child: YgExpandingListTile(
+              initiallyExpanded: true,
+              title: YgGoldenTestValues.shortText,
+              alwaysVisibleContent: alwaysVisibleContent,
               child: child,
             ),
           ),


### PR DESCRIPTION
# Checklist

- [ ] Self review has been performed.
- [ ] PR description contains information about what's new using valid PR tags.
- [ ] Add video with happy path or screenshot.

# Changes

[feature] Added alwaysVisibleContent property (Widget?) to YgExpandingListTile - content rendered below the tile row that stays visible while the tile is collapsed, e.g. a temperature slider usable without expanding the tile.
