### PR TITLE
fix barely visible font of YgListTile

### DIFF
--- a/yggdrasil/lib/src/theme/list_tile/list_tile_theme.dart
+++ b/yggdrasil/lib/src/theme/list_tile/list_tile_theme.dart
@@ -25,17 +25,17 @@ class _$YgListTileTheme {
   ];
 
   static final List<TextStyle> subtitleTextStyle = <TextStyle>[
-    consumer_light.FhTextStyles.caption1Regular.copyWith(
-      color: consumer_light.FhColors.textWeak,
+    consumer_light.FhTextStyles.paragraph3Regular.copyWith(
+      color: consumer_light.FhColors.textDefault,
     ),
-    consumer_dark.FhTextStyles.caption1Regular.copyWith(
-      color: consumer_dark.FhColors.textWeak,
+    consumer_dark.FhTextStyles.paragraph3Regular.copyWith(
+      color: consumer_dark.FhColors.textDefault,
     ),
-    professional_light.FhTextStyles.caption1Regular.copyWith(
-      color: professional_light.FhColors.textWeak,
+    professional_light.FhTextStyles.paragraph3Regular.copyWith(
+      color: professional_light.FhColors.textDefault,
     ),
-    professional_dark.FhTextStyles.caption1Regular.copyWith(
-      color: professional_dark.FhColors.textWeak,
+    professional_dark.FhTextStyles.paragraph3Regular.copyWith(
+      color: professional_dark.FhColors.textDefault,
     ),
   ];
 

--- a/yggdrasil/lib/src/theme/section/extensions/section_header_theme.dart
+++ b/yggdrasil/lib/src/theme/section/extensions/section_header_theme.dart
@@ -27,16 +27,16 @@ class _$YgSectionHeaderTheme {
 
   static final List<TextStyle> subtitleTextStyle = <TextStyle>[
     consumer_light.FhTextStyles.paragraph3Regular.copyWith(
-      color: consumer_light.FhColors.textWeak,
+      color: consumer_light.FhColors.textDefault,
     ),
     consumer_dark.FhTextStyles.paragraph3Regular.copyWith(
-      color: consumer_dark.FhColors.textWeak,
+      color: consumer_dark.FhColors.textDefault,
     ),
     professional_light.FhTextStyles.paragraph3Regular.copyWith(
-      color: professional_light.FhColors.textWeak,
+      color: professional_light.FhColors.textDefault,
     ),
     professional_dark.FhTextStyles.paragraph3Regular.copyWith(
-      color: professional_dark.FhColors.textWeak,
+      color: professional_dark.FhColors.textDefault,
     ),
   ];
 


### PR DESCRIPTION
# Checklist

- [ ] Self review has been performed.
- [ ] PR description contains information about what's new using valid PR tags.
- [ ] Add video with happy path or screenshot.

# Changes


[change] YgListTile subtitle now uses paragraph3Regular (14/20, w400) instead of caption1Regular (12/16, w400), matching YgSection's description text style.
[change] Both YgListTile subtitle and YgSection description now use FhColors.textDefault instead of FhColors.textWeak, since the weak/gray color was too low-contrast to read comfortably. Applied consistently across all four theme variants (consumer light/dark, professional light/dark).


#Why
  
The subtitle/description text was barely visible at the old size and color. Aligning both components on the same text style also keeps subtitle/description typography consistent across the design system.


